### PR TITLE
Remove namespace specification from the README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ result = flip_coin()
 couler.when(couler.equal(result, "heads"), lambda: heads())
 couler.when(couler.equal(result, "tails"), lambda: tails())
 
-submitter = ArgoSubmitter(namespace="argo")
+submitter = ArgoSubmitter()
 couler.run(submitter=submitter)
 ```
 
@@ -247,7 +247,7 @@ def diamond():
 
 
 linear()
-submitter = ArgoSubmitter(namespace="argo")
+submitter = ArgoSubmitter()
 couler.run(submitter=submitter)
 ```
 


### PR DESCRIPTION
Better to take the default setting in users' local kubeconfig. Easy to get started when trying in local Minikube.