### PR TITLE
Enable S3 Artifact usage

### DIFF
--- a/couler/argo.py
+++ b/couler/argo.py
@@ -36,7 +36,12 @@ from couler.core.states import (  # noqa: F401
     workflow,
 )
 from couler.core.syntax import *  # noqa: F401, F403
-from couler.core.templates import Artifact, OssArtifact, Secret  # noqa: F401
+from couler.core.templates import (  # noqa: F401
+    Artifact,
+    OssArtifact,
+    S3Artifact,
+    Secret,
+)
 from couler.core.workflow_validation_utils import (  # noqa: F401
     validate_workflow_yaml,
 )
@@ -165,6 +170,36 @@ def create_oss_artifact(
     :return:
     """
     return OssArtifact(
+        path,
+        accesskey_id,
+        accesskey_secret,
+        bucket,
+        key=key,
+        endpoint=endpoint,
+        is_global=is_global,
+    )
+
+
+def create_s3_artifact(
+    path,
+    bucket=None,
+    accesskey_id=None,
+    accesskey_secret=None,
+    key=None,
+    endpoint=None,
+    is_global=False,
+):
+    """
+    Configure the object as S3Artifact
+    :param path: the local path of container
+    :param bucket: s3 bucket
+    :param accesskey_id: s3 user id
+    :param accesskey_secret: s3 user key
+    :param key: key of s3 object
+    :param endpoint: end point of s3
+    :return:
+    """
+    return S3Artifact(
         path,
         accesskey_id,
         accesskey_secret,

--- a/couler/core/templates/__init__.py
+++ b/couler/core/templates/__init__.py
@@ -11,7 +11,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from couler.core.templates.artifact import Artifact, OssArtifact  # noqa: F401
+from couler.core.templates.artifact import (  # noqa: F401
+    Artifact,
+    OssArtifact,
+    S3Artifact,
+)
 from couler.core.templates.container import Container  # noqa: F401
 from couler.core.templates.job import Job  # noqa: F401
 from couler.core.templates.output import (  # noqa: F401

--- a/couler/core/templates/artifact.py
+++ b/couler/core/templates/artifact.py
@@ -37,6 +37,65 @@ class Artifact(object):
         return yaml_output
 
 
+class S3Artifact(Artifact):
+    """
+    OssArtifact build the mapping from local path to remote oss bucekt,
+    user can read/write data from OSS as read/write local file
+    """
+
+    def __init__(
+        self,
+        path,
+        accesskey_id,
+        accesskey_secret,
+        bucket,
+        key=None,
+        endpoint="s3.amazonaws.com",
+        is_global=False,
+    ):
+        self.id = "output-s3-%s" % utils._get_uuid()
+        # path is used for local path
+        self.path = path
+        self.type = "s3"
+        self.is_global = is_global
+
+        if accesskey_secret is None or accesskey_id is None or bucket is None:
+            raise SyntaxError("need to input the correct config for s3")
+
+        self.bucket = bucket
+
+        if key is None:
+            # assume the local path is the same as the path of OSS
+            self.key = path
+        else:
+            self.key = key
+
+        self.endpoint = endpoint
+
+        import couler.argo as couler
+
+        secrets = {"accessKey": accesskey_id, "secretKey": accesskey_secret}
+        # TODO: check this secret exist or not
+        self.secret = couler.create_secret(secrets)
+
+    def to_yaml(self):
+        s3_config = OrderedDict(
+            {
+                "endpoint": self.endpoint,
+                "bucket": self.bucket,
+                "key": self.key,
+                "accessKeySecret": {"name": self.secret, "key": "accessKey"},
+                "secretKeySecret": {"name": self.secret, "key": "secretKey"},
+            }
+        )
+        yaml_output = OrderedDict(
+            {"name": self.id, "path": self.path, "s3": s3_config}
+        )
+        if self.is_global:
+            yaml_output["globalName"] = "global-" + self.id
+        return yaml_output
+
+
 class OssArtifact(Artifact):
     """
     OssArtifact build the mapping from local path to remote oss bucekt,

--- a/couler/core/templates/container.py
+++ b/couler/core/templates/container.py
@@ -16,7 +16,7 @@ from collections import OrderedDict
 
 from couler.core import utils
 from couler.core.constants import OVERWRITE_GPU_ENVS
-from couler.core.templates.artifact import OssArtifact
+from couler.core.templates.artifact import TypedArtifact
 from couler.core.templates.output import OutputArtifact, OutputJob
 from couler.core.templates.secret import Secret
 from couler.core.templates.template import Template
@@ -95,7 +95,7 @@ class Container(Template):
         if self.input is not None:
             _input_list = []
             for o in self.input:
-                if isinstance(o, OssArtifact):
+                if isinstance(o, TypedArtifact):
                     _input_list.append(o.to_yaml())
                 if isinstance(o, OutputArtifact):
                     _input_list.append(o.artifact)
@@ -119,7 +119,7 @@ class Container(Template):
             for o in self.output:
                 _output_list.append(o.to_yaml())
 
-            if isinstance(o, OssArtifact):
+            if isinstance(o, TypedArtifact):
                 # Require only one kind of output type
                 template["outputs"] = {"artifacts": _output_list}
             else:


### PR DESCRIPTION
Currently, only OSS Artifacts are supported. This PR adds an `S3` Artifact sub-class.

I still haven't added tests for this, but I wanted to open this PR to discuss how this type of change is supposed to be implemented. Is the method in the first commit, where I duplicate code between `OSSArtifact` and `S3Artifact`, acceptable? Alternatively, is the second commit, where I create a `TypedArtifact` subclass better?

