### PR TITLE
Add support for transient PVCs in workflows

### DIFF
--- a/couler/core/syntax/__init__.py
+++ b/couler/core/syntax/__init__.py
@@ -18,4 +18,7 @@ from couler.core.syntax.exit_handler import set_exit_handler  # noqa: F401
 from couler.core.syntax.loop import map  # noqa: F401
 from couler.core.syntax.predicates import *  # noqa: F401, F403
 from couler.core.syntax.recursion import exec_while  # noqa: F401
-from couler.core.syntax.volume import add_volume  # noqa: F401
+from couler.core.syntax.volume import (  # noqa: F401
+    add_volume,
+    create_workflow_volume,
+)

--- a/couler/core/syntax/volume.py
+++ b/couler/core/syntax/volume.py
@@ -13,6 +13,7 @@
 
 from couler.core import states
 from couler.core.templates.volume import Volume
+from couler.core.templates.volume_claim import VolumeClaimTemplate
 
 
 def add_volume(volume: Volume):
@@ -23,3 +24,13 @@ def add_volume(volume: Volume):
     https://github.com/argoproj/argo/blob/master/examples/volumes-existing.yaml
     """
     states.workflow.add_volume(volume)
+
+
+def create_workflow_volume(volume_claim_template: VolumeClaimTemplate):
+    """
+    Create a transient volume for use in the workflow.
+
+    Reference:
+    https://github.com/argoproj/argo/blob/master/examples/volumes-pvc.yaml
+    """
+    states.workflow.add_pvc_template(volume_claim_template)

--- a/couler/core/templates/volume_claim.py
+++ b/couler/core/templates/volume_claim.py
@@ -1,0 +1,38 @@
+# Copyright 2020 The Couler Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections import OrderedDict
+from typing import List
+
+
+class VolumeClaimTemplate(object):
+    def __init__(
+        self,
+        claim_name: str,
+        access_modes: List[str] = ["ReadWriteOnce"],
+        size: str = "1Gi",
+    ):
+        self.claim_name = claim_name
+        self.access_modes = access_modes
+        self.size = size
+
+    def to_dict(self):
+        return OrderedDict(
+            {
+                "metadata": {"name": self.claim_name},
+                "spec": {
+                    "accessModes": self.access_modes,
+                    "resources": {"requests": {"storage": self.size}},
+                },
+            }
+        )

--- a/couler/core/templates/workflow.py
+++ b/couler/core/templates/workflow.py
@@ -16,6 +16,7 @@ from collections import OrderedDict
 from couler.core import utils
 from couler.core.templates import Container, Job, Script, Step, Template
 from couler.core.templates.volume import Volume
+from couler.core.templates.volume_claim import VolumeClaimTemplate
 
 
 class Workflow(object):
@@ -35,6 +36,7 @@ class Workflow(object):
         self.cluster_config = utils.load_cluster_config()
         self.cron_config = None
         self.volumes = []
+        self.pvcs = []
 
     def add_template(self, template: Template):
         self.templates.update({template.name: template})
@@ -46,6 +48,9 @@ class Workflow(object):
         if name not in self.steps:
             self.steps.update({name: []})
         self.steps.get(name).append(step)
+
+    def add_pvc_template(self, pvc: VolumeClaimTemplate):
+        self.pvcs.append(pvc.to_dict())
 
     def add_volume(self, volume: Volume):
         self.volumes.append(volume.to_dict())
@@ -110,6 +115,8 @@ class Workflow(object):
         workflow_spec = {"entrypoint": entrypoint}
         if self.volumes:
             workflow_spec.update({"volumes": self.volumes})
+        if self.pvcs:
+            workflow_spec.update({"volumeClaimTemplates": self.pvcs})
         if self.dag_mode_enabled():
             dag = {"tasks": list(self.dag_tasks.values())}
             ts = [OrderedDict({"name": entrypoint, "dag": dag})]
@@ -172,3 +179,4 @@ class Workflow(object):
         self.cluster_config = None
         self.cron_config = None
         self.volumes = []
+        self.pvcs = []


### PR DESCRIPTION
### What changes were proposed in this pull request?
Argo [has support for creating per-workflow PVCs](https://github.com/argoproj/argo/blob/master/examples/volumes-pvc.yaml), allowing users to create a PVC which is terminated once the workflow is finished.  This pull request adds couler support for creating a transient PVC that can be used within a workflow.

### Why are the changes needed?
For many ML applications, it's convenient to place data on a filesystem for processing over the course of multiple workflow steps.  This change makes it much easier to create a temporary mount for a single workflow.


### Does this PR introduce _any_ user-facing change?
This PR adds a single additional user-facing function, a helper function for adding a pvc to a workflow:
```py
from couler.core.syntax import create_workflow_volume
```

### How was this patch tested?
The following workflow can be used to validate this change.  It creates a workflow volume, mounts it to two steps, and validates data transfer between the two steps.

```py
import os

import couler.argo as couler
from couler.argo_submitter import ArgoSubmitter
from couler.core.templates.volume_claim import VolumeClaimTemplate
from couler.core.templates.volume import VolumeMount
from couler.core.syntax import create_workflow_volume


def touch_op(data_mount):
    command = ["touch", os.path.join(data_mount.mount_path, 'hello_world.txt')]
    return couler.run_container(
        image="alpine:3.12.0", command=command, volume_mounts=[data_mount]
    )


def ls_op(data_mount):
    command = ["ls", data_mount.mount_path]
    return couler.run_container(
        image="alpine:3.12.0", command=command, volume_mounts=[data_mount]
    )


volume_name = "pvc-test"
volume_path = "/data/"
pvc = VolumeClaimTemplate(volume_name)
mount = VolumeMount(volume_name, volume_path)
create_workflow_volume(pvc)
touch_op(mount)
ls_op(mount)

submitter = ArgoSubmitter(namespace="argo")
couler.run(submitter=submitter)
```
