### PR TITLE
docs: Add initial list of Couler adopters

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -5,7 +5,7 @@ This page contains a list of organizations who are using Couler. If you'd like t
 | Organization | Contact |
 | ------------ | ------- |
 | [Ant Group](https://www.antgroup.com/) | [Couler Team](https://github.com/orgs/couler-proj/teams/couler-team) |
-| [Bytedance](https://www.bytedance.com/en/) | [Tianxin Dong](https://github.com/FogDong) |
-| [Determined](https://github.com/determined-ai/determined) | [David Hershey](https://github.com/davidhershey) and [Vishnu Mohan](https://github.com/vishnu2kmohan) |
+| [Bytedance](https://www.bytedance.com/) | [Tianxin Dong](https://github.com/FogDong) |
+| [Determined](https://determined.ai/) | [David Hershey](https://github.com/davidhershey) and [Vishnu Mohan](https://github.com/vishnu2kmohan) |
 | [Kabam](https://kabam.com/) | [Yudi Xue](https://github.com/binarycrayon) |
 | [Pipekit](https://pipekit.io/) | [J.P. Zivalich](https://github.com/JPZ13) |

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,11 @@
+# Adopters of Couler
+
+This page contains a list of organizations who are using Couler. If you'd like to be included here, please send a pull request which modifies this file. Please keep the list in alphabetical order.
+
+| Organization | Contact |
+| ------------ | ------- |
+| [Ant Group](https://www.antgroup.com/) | [Couler Team](https://github.com/orgs/couler-proj/teams/couler-team) |
+| [Bytedance](https://www.bytedance.com/en/) | [Tianxin Dong](https://github.com/FogDong) |
+| [Determined](https://github.com/determined-ai/determined) | [David Hershey](https://github.com/davidhershey) and [Vishnu Mohan](https://github.com/vishnu2kmohan) |
+| [Kabam](https://kabam.com/) | [Yudi Xue](https://github.com/binarycrayon) |
+| [Pipekit](https://pipekit.io/) | [J.P. Zivalich](https://github.com/JPZ13) |

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@
 Couler aims to provide a unified interface for constructing and managing workflows on
 different workflow engines, such as [Argo Workflows](https://github.com/argoproj/argo), [Tekton Pipelines](https://tekton.dev/), and [Apache Airflow](https://airflow.apache.org/).
 
+## Who uses Couler?
+
+You can find a list of organizations who are using Couler in [ADOPTERS.md](ADOPTERS.md). If you'd like to add your organization to the list, please send us a pull request.
+
 ## Why use Couler?
 
 Many workflow engines exist nowadays, e.g. [Argo Workflows](https://github.com/argoproj/argo), [Tekton Pipelines](https://tekton.dev/), and [Apache Airflow](https://airflow.apache.org/).


### PR DESCRIPTION
Hi community,

This PR adds a document `ADOPTERS.md` that contains an initial list of organizations who are using Couler. If you'd like to add your organization to the list, please comment here or send us a pull request that modifies `ADOPTERS.md`. Thanks everyone for your continuous support and contributions!

cc @couler-proj/couler-team  @davidhershey @vishnu2kmohan @binarycrayon @JPZ13 @FogDong @gaocegege

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>