### PR TITLE
fix: Fix incorrect optimization package name

### DIFF
--- a/go/couler/optimization/optimization.go
+++ b/go/couler/optimization/optimization.go
@@ -1,4 +1,4 @@
-package server
+package optimization
 
 import (
 	"fmt"

--- a/go/couler/optimization/optimization_test.go
+++ b/go/couler/optimization/optimization_test.go
@@ -1,10 +1,9 @@
-package server_test
+package optimization
 
 import (
 	"testing"
 
 	"github.com/alecthomas/assert"
-	opt "github.com/couler-proj/couler/go/couler/optimization"
 	pb "github.com/couler-proj/couler/go/couler/proto/couler/v1"
 )
 
@@ -22,7 +21,7 @@ func TestComposePass(t *testing.T) {
 	w.Steps = []*pb.Step{&pb.Step{Name: "node1"}}
 
 	// EndNodePass would add a node with name "endnode" at the tail
-	opt := opt.Compose(&EndNodePass{})
+	opt := Compose(&EndNodePass{})
 	w, e := opt.Run(w)
 	a.NoError(e)
 	a.Equal(len(w.Steps), 2)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/couler-proj/couler/blob/master/CODE_OF_CONDUCT.md
  2. Ensure you have added or run the appropriate tests for your PR: https://github.com/couler-proj/couler/blob/master/CONTRIBUTING.md
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. 
-->
Fix incorrect optimization package name. cc @Yancey1989 


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Package name is incorrect.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Part of the CI.