### PR TITLE
feat: add gen proto for run_job

### DIFF
--- a/couler/core/proto_repr.py
+++ b/couler/core/proto_repr.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 
 from couler.core import utils
+from couler.core.templates.output import OutputJob
 from couler.proto import couler_pb2
 
 DEFAULT_WORKFLOW = None
@@ -80,6 +81,27 @@ def step_repr(
 
     for i, io in enumerate([input, output]):
         if io is not None:
+            # NOTE: run_job will pass type OutputJob here
+            if isinstance(io, OutputJob):
+                o = couler_pb2.StepIO()
+                o.source = pb_step.id
+                o.parameter.name = "job-name"
+                o.parameter.value = io.job_name
+                pb_step.outputs.append(o)
+
+                o = couler_pb2.StepIO()
+                o.source = pb_step.id
+                o.parameter.name = "job-id"
+                o.parameter.value = io.job_id
+                pb_step.outputs.append(o)
+
+                o = couler_pb2.StepIO()
+                o.source = pb_step.id
+                o.parameter.name = "job-obj"
+                o.parameter.value = io.job_obj
+                pb_step.outputs.append(o)
+                break
+
             if "artifacts" in io:
                 art_list = io["artifacts"]
                 for a in art_list:

--- a/couler/core/run_templates.py
+++ b/couler/core/run_templates.py
@@ -271,6 +271,9 @@ def run_job(
     if manifest is None:
         raise ValueError("Input manifest can not be null")
 
+    manifest_image = None
+    manifest_command = None
+
     func_name, caller_line = utils.invocation_location()
     func_name = (
         utils.argo_safe_name(step_name) if step_name is not None else func_name
@@ -320,4 +323,24 @@ def run_job(
     # return job name and job uid for reference
     rets = _job_output(step_name, func_name)
     states._steps_outputs[step_name] = rets
+
+    # get image, command from manifest, raise exception if no
+    manifest_dict = yaml.safe_load(manifest)
+    manifest_image = manifest_dict["spec"]["template"]["spec"]["containers"][
+        0
+    ]["image"]
+    manifest_command = manifest_dict["spec"]["template"]["spec"]["containers"][
+        0
+    ]["command"]
+    pb_step = proto_repr.step_repr(  # noqa: F841
+        step_name=step_name,
+        tmpl_name=func_name,
+        image=manifest_image,
+        command=manifest_command,
+        source=None,
+        script_output=None,
+        input=None,
+        output=rets,
+    )
+
     return rets

--- a/couler/core/run_templates.py
+++ b/couler/core/run_templates.py
@@ -271,9 +271,6 @@ def run_job(
     if manifest is None:
         raise ValueError("Input manifest can not be null")
 
-    manifest_image = None
-    manifest_command = None
-
     func_name, caller_line = utils.invocation_location()
     func_name = (
         utils.argo_safe_name(step_name) if step_name is not None else func_name
@@ -324,23 +321,17 @@ def run_job(
     rets = _job_output(step_name, func_name)
     states._steps_outputs[step_name] = rets
 
-    # get image, command from manifest, raise exception if no
-    manifest_dict = yaml.safe_load(manifest)
-    manifest_image = manifest_dict["spec"]["template"]["spec"]["containers"][
-        0
-    ]["image"]
-    manifest_command = manifest_dict["spec"]["template"]["spec"]["containers"][
-        0
-    ]["command"]
     pb_step = proto_repr.step_repr(  # noqa: F841
         step_name=step_name,
         tmpl_name=func_name,
-        image=manifest_image,
-        command=manifest_command,
+        image=None,
         source=None,
         script_output=None,
         input=None,
         output=rets,
+        manifest=manifest,
+        success_cond=success_condition,
+        failure_cond=failure_condition,
     )
 
     return rets

--- a/couler/core/run_templates.py
+++ b/couler/core/run_templates.py
@@ -315,7 +315,9 @@ def run_job(
         )
         states.workflow.add_template(template)
 
-    step_update_utils.update_step(func_name, args, step_name, caller_line)
+    step_name = step_update_utils.update_step(
+        func_name, args, step_name, caller_line
+    )
 
     # return job name and job uid for reference
     rets = _job_output(step_name, func_name)

--- a/couler/tests/proto_repr_test.py
+++ b/couler/tests/proto_repr_test.py
@@ -39,6 +39,33 @@ class ProtoReprTest(unittest.TestCase):
 
         couler._cleanup()
 
+    def test_run_job(self):
+        success_condition = "status.succeeded > 0"
+        failure_condition = "status.failed > 3"
+        manifest = """apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: rand-num-
+spec:
+    template:
+      spec:
+        containers:
+        - name: rand
+          image: python:3.6
+          command: ["python random_num.py"]
+"""
+        couler.run_job(
+            manifest=manifest,
+            success_condition=success_condition,
+            failure_condition=failure_condition,
+            step_name="test_run_job",
+        )
+        proto_wf = get_default_proto_workflow()
+        s = proto_wf.steps[0]
+        self.assertEqual(s.container_spec.image, "python:3.6")
+
+        couler._cleanup()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/couler/tests/proto_repr_test.py
+++ b/couler/tests/proto_repr_test.py
@@ -5,6 +5,9 @@ from couler.core.proto_repr import get_default_proto_workflow
 
 
 class ProtoReprTest(unittest.TestCase):
+    def tearDown(self):
+        couler._cleanup()
+
     def test_script_step(self):
         def echo():
             print("echo")
@@ -13,8 +16,6 @@ class ProtoReprTest(unittest.TestCase):
         proto_wf = get_default_proto_workflow()
         s = proto_wf.steps[0]
         self.assertEqual(s.script, '\nprint("echo")\n')
-
-        couler._cleanup()
 
     def test_output_oss_artifact(self):
         # the content of local file would be uploaded to OSS
@@ -36,8 +37,6 @@ class ProtoReprTest(unittest.TestCase):
         s = proto_wf.steps[0]
         self.assertEqual(s.container_spec.image, "docker/whalesay:latest")
         self.assertTrue(s.outputs[0].artifact.name.startswith("output-oss"))
-
-        couler._cleanup()
 
     def test_run_job(self):
         success_condition = "status.succeeded > 0"
@@ -62,9 +61,11 @@ spec:
         )
         proto_wf = get_default_proto_workflow()
         s = proto_wf.steps[0]
-        self.assertEqual(s.container_spec.image, "python:3.6")
-
-        couler._cleanup()
+        self.assertEqual(s.resource_spec.manifest, manifest)
+        self.assertEqual(s.resource_spec.success_condition, success_condition)
+        self.assertEqual(s.resource_spec.failure_condition, failure_condition)
+        self.assertEqual(len(s.outputs), 3)
+        self.assertEqual(s.outputs[0].parameter.name, "job-name")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`couler.run_job` can generate protobuf formated structure for future use.