### PR TITLE
feat: Add artifact secret detail in proto

### DIFF
--- a/couler/core/proto_repr.py
+++ b/couler/core/proto_repr.py
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from couler.core import utils
+from couler.core import states, utils  # noqa: F401
 from couler.core.templates.output import OutputJob
 from couler.proto import couler_pb2
 
@@ -133,8 +133,12 @@ def step_repr(
                     a.bucket = attrs["bucket"]
                     a.access_key.name = attrs["accessKeySecret"]["name"]
                     a.access_key.key = attrs["accessKeySecret"]["key"]
+                    s = states._secrets[a.access_key.name]
+                    a.access_key.value = s.data[a.access_key.key]
                     a.secret_key.name = attrs["secretKeySecret"]["name"]
                     a.secret_key.key = attrs["secretKeySecret"]["key"]
+                    s = states._secrets[a.secret_key.name]
+                    a.secret_key.value = s.data[a.secret_key.key]
                     if "globalName" in art:
                         a.global_name = art["globalName"]
 

--- a/couler/tests/proto_repr_test.py
+++ b/couler/tests/proto_repr_test.py
@@ -1,6 +1,7 @@
 import unittest
 
 import couler.argo as couler
+from couler.core import states
 from couler.core.proto_repr import get_default_proto_workflow
 
 
@@ -42,7 +43,11 @@ class ProtoReprTest(unittest.TestCase):
         self.assertEqual(s.outputs[0].artifact.bucket, "test-bucket/")
 
         self.assertEqual(s.outputs[0].artifact.access_key.key, "accessKey")
-        self.assertEqual(s.outputs[0].artifact.secret_key.key, "secretKey")
+        proto_sk = s.outputs[0].artifact.secret_key
+        self.assertEqual(proto_sk.key, "secretKey")
+        self.assertEqual(
+            proto_sk.value, states._secrets[proto_sk.name].data[proto_sk.key]
+        )
 
     def test_run_job(self):
         success_condition = "status.succeeded > 0"

--- a/proto/couler.proto
+++ b/proto/couler.proto
@@ -16,6 +16,7 @@ message Parameter {
 message Secret {
   string name = 1;
   string key = 2;
+  string value = 3;  // BASE64 encoded secret value
 }
 
 message Artifact {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add artifact secret details in the proto description.


### Why are the changes needed?

The protobuf representation needs the secret value details in order to submit jobs to K8S.

### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?

Unit tests are added.
