### PR TITLE
fix: proto.go file path

### DIFF
--- a/go/couler/proto/couler/v1/proto.go
+++ b/go/couler/proto/couler/v1/proto.go
@@ -1,0 +1,3 @@
+//go:generate protoc --go_out=../../. ../../../../../proto/couler.proto -I ../../../../../proto
+
+package v1

--- a/go/couler/proto/proto.go
+++ b/go/couler/proto/proto.go
@@ -1,3 +1,0 @@
-//go:generate protoc --go_out=. ../../../proto/couler.proto -I ../../../proto
-
-package v1


### PR DESCRIPTION
fix `proto.go` file path to fit the package name.
