### PR TITLE
ci: Allow manual trigger of GitHub Actions builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
See https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/. This would allow maintainers to trigger builds on a branch without creating a PR.