### PR TITLE
fix: Avoid appending command  to proto when step contains manifest

### DIFF
--- a/couler/core/proto_repr.py
+++ b/couler/core/proto_repr.py
@@ -69,14 +69,15 @@ def step_repr(
         if success_cond is not None and failure_cond is not None:
             pb_step.resource_spec.success_condition = success_cond
             pb_step.resource_spec.failure_condition = failure_cond
-    elif command is None:
-        pb_step.container_spec.command.append("python")
-    elif isinstance(command, list):
-        pb_step.container_spec.command.extend(command)
-    elif isinstance(command, str):
-        pb_step.container_spec.command.append(command)
     else:
-        raise ValueError("command must be str or list")
+        if command is None:
+            pb_step.container_spec.command.append("python")
+        elif isinstance(command, list):
+            pb_step.container_spec.command.extend(command)
+        elif isinstance(command, str):
+            pb_step.container_spec.command.append(command)
+        else:
+            raise ValueError("command must be str or list")
     if source is not None:
         if isinstance(source, str):
             pb_step.script = source

--- a/couler/core/proto_repr.py
+++ b/couler/core/proto_repr.py
@@ -66,10 +66,10 @@ def step_repr(
         pb_step.container_spec.image = image
     if manifest is not None:
         pb_step.resource_spec.manifest = manifest
-    if success_cond is not None:
-        pb_step.resource_spec.success_condition = success_cond
-        pb_step.resource_spec.failure_condition = failure_cond
-    if command is None:
+        if success_cond is not None and failure_cond is not None:
+            pb_step.resource_spec.success_condition = success_cond
+            pb_step.resource_spec.failure_condition = failure_cond
+    elif command is None:
         pb_step.container_spec.command.append("python")
     elif isinstance(command, list):
         pb_step.container_spec.command.extend(command)

--- a/couler/tests/proto_repr_test.py
+++ b/couler/tests/proto_repr_test.py
@@ -16,6 +16,7 @@ class ProtoReprTest(unittest.TestCase):
         couler.run_script(image="docker/whalesay:latest", source=echo)
         proto_wf = get_default_proto_workflow()
         s = proto_wf.steps[0].steps[0]
+        self.assertFalse(s.HasField("resource_spec"))
         self.assertEqual(s.script, '\nprint("echo")\n')
 
     def test_when(self):

--- a/couler/tests/proto_repr_test.py
+++ b/couler/tests/proto_repr_test.py
@@ -115,6 +115,7 @@ spec:
         proto_wf = get_default_proto_workflow()
         s = proto_wf.steps[0].steps[0]
         t = proto_wf.templates[s.tmpl_name]
+        self.assertFalse(s.HasField("container_spec"))
         self.assertEqual(s.resource_spec.manifest, manifest)
         self.assertEqual(s.resource_spec.success_condition, success_condition)
         self.assertEqual(s.resource_spec.failure_condition, failure_condition)


### PR DESCRIPTION
Currently `command: python` is appended to step proto when this step contains manifest (resource type), which is incorrect and this PR fixes it. 