### PR TITLE
feat: env value use string type

### DIFF
--- a/couler/core/proto_repr.py
+++ b/couler/core/proto_repr.py
@@ -11,6 +11,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
+
 from couler.core import states, utils  # noqa: F401
 from couler.core.templates.output import OutputArtifact, OutputJob
 from couler.proto import couler_pb2
@@ -66,7 +68,10 @@ def step_repr(
     pb_step.tmpl_name = tmpl_name
     if env is not None:
         for k, v in env.items():
-            pb_step.container_spec.env[k] = v
+            if isinstance(v, str):
+                pb_step.container_spec.env[k] = v
+            else:
+                pb_step.container_spec.env[k] = json.dumps(v)
 
     # image can be None if manifest specified.
     if image is not None:

--- a/couler/core/proto_repr.py
+++ b/couler/core/proto_repr.py
@@ -46,6 +46,7 @@ def step_repr(
     image=None,
     command=None,
     source=None,
+    env=None,
     script_output=None,
     args=None,
     input=None,
@@ -63,6 +64,10 @@ def step_repr(
     pb_step.id = get_uniq_step_id()
     pb_step.name = step_name
     pb_step.tmpl_name = tmpl_name
+    if env is not None:
+        for k, v in env.items():
+            pb_step.container_spec.env[k] = v
+
     # image can be None if manifest specified.
     if image is not None:
         pb_step.container_spec.image = image

--- a/couler/core/run_templates.py
+++ b/couler/core/run_templates.py
@@ -90,6 +90,7 @@ def run_script(
         command=command,
         source=source,
         script_output=rets,
+        env=env,
     )
 
     return rets

--- a/go/couler/conversion/argo_workflow.go
+++ b/go/couler/conversion/argo_workflow.go
@@ -86,7 +86,7 @@ func createSingleStepTemplate(step *pb.Step, workflowPb *pb.Workflow) wfv1.Templ
 		containerSpec := step.GetContainerSpec()
 		var env []corev1.EnvVar
 		for k, v := range containerSpec.GetEnv() {
-			env = append(env, corev1.EnvVar{Name: k, Value: v.String()})
+			env = append(env, corev1.EnvVar{Name: k, Value: v})
 		}
 		container := &corev1.Container{
 			Image:   containerSpec.GetImage(),

--- a/proto/couler.proto
+++ b/proto/couler.proto
@@ -55,7 +55,7 @@ message StepIO {
 message ContainerSpec {
     string image = 1;
     repeated string command = 2;
-    map<string, google.protobuf.Any> env = 3;
+    map<string, string> env = 3;
 }
 
 message ResourceSpec {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Environment variables are always string typed in any OS, so change the protobuf message to the string type. Previous `Any` type may introduce complexity and bugs.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
The current unit tests can cover the change.