### PR TITLE
fix: added copyright notices for python scripts

### DIFF
--- a/couler/proto/__init__.py
+++ b/couler/proto/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2021 The Couler Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/couler/steps/katib.py
+++ b/couler/steps/katib.py
@@ -1,3 +1,16 @@
+# Copyright 2021 The Couler Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from io import StringIO
 
 import yaml

--- a/couler/steps/mpi.py
+++ b/couler/steps/mpi.py
@@ -1,3 +1,16 @@
+# Copyright 2021 The Couler Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import copy
 import uuid
 

--- a/couler/steps/pod_utils.py
+++ b/couler/steps/pod_utils.py
@@ -1,3 +1,16 @@
+# Copyright 2021 The Couler Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import copy
 
 import couler.argo as couler

--- a/couler/steps/pytorch.py
+++ b/couler/steps/pytorch.py
@@ -1,3 +1,16 @@
+# Copyright 2021 The Couler Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import copy
 import uuid
 

--- a/couler/steps/tensorflow.py
+++ b/couler/steps/tensorflow.py
@@ -1,3 +1,16 @@
+# Copyright 2021 The Couler Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import copy
 import uuid
 

--- a/couler/tests/__init__.py
+++ b/couler/tests/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2021 The Couler Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/couler/tests/argo_test.py
+++ b/couler/tests/argo_test.py
@@ -1,3 +1,16 @@
+# Copyright 2021 The Couler Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import unittest
 from collections import OrderedDict
 

--- a/couler/tests/argo_yaml_test.py
+++ b/couler/tests/argo_yaml_test.py
@@ -1,3 +1,16 @@
+# Copyright 2021 The Couler Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import json
 import os
 import re

--- a/couler/tests/artifact_test.py
+++ b/couler/tests/artifact_test.py
@@ -1,3 +1,16 @@
+# Copyright 2021 The Couler Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import couler.argo as couler
 from couler.tests.argo_yaml_test import ArgoYamlTest
 

--- a/couler/tests/cluster_config_test.py
+++ b/couler/tests/cluster_config_test.py
@@ -1,3 +1,16 @@
+# Copyright 2021 The Couler Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 
 import couler.argo as couler

--- a/couler/tests/cron_workflow_test.py
+++ b/couler/tests/cron_workflow_test.py
@@ -1,3 +1,16 @@
+# Copyright 2021 The Couler Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import couler.argo as couler
 from couler.tests.argo_yaml_test import ArgoYamlTest
 

--- a/couler/tests/daemon_step_test.py
+++ b/couler/tests/daemon_step_test.py
@@ -1,3 +1,16 @@
+# Copyright 2021 The Couler Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import couler.argo as couler
 from couler.tests.argo_test import ArgoBaseTestCase
 

--- a/couler/tests/dag_test.py
+++ b/couler/tests/dag_test.py
@@ -1,3 +1,16 @@
+# Copyright 2021 The Couler Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import pyaml
 
 import couler.argo as couler

--- a/couler/tests/env_test.py
+++ b/couler/tests/env_test.py
@@ -1,3 +1,16 @@
+# Copyright 2021 The Couler Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import copy
 
 import couler.argo as couler

--- a/couler/tests/input_parameter_test.py
+++ b/couler/tests/input_parameter_test.py
@@ -1,3 +1,16 @@
+# Copyright 2021 The Couler Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from collections import OrderedDict
 
 import couler.argo as couler

--- a/couler/tests/katib_step_test.py
+++ b/couler/tests/katib_step_test.py
@@ -1,3 +1,16 @@
+# Copyright 2021 The Couler Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import couler.argo as couler
 import couler.steps.katib as katib
 from couler.tests.argo_test import ArgoBaseTestCase

--- a/couler/tests/map_test.py
+++ b/couler/tests/map_test.py
@@ -1,3 +1,16 @@
+# Copyright 2021 The Couler Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import couler.argo as couler
 from couler.tests.argo_yaml_test import ArgoYamlTest
 

--- a/couler/tests/mpi_step_test.py
+++ b/couler/tests/mpi_step_test.py
@@ -1,3 +1,16 @@
+# Copyright 2021 The Couler Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from io import StringIO
 
 import yaml

--- a/couler/tests/proto_repr_test.py
+++ b/couler/tests/proto_repr_test.py
@@ -1,3 +1,16 @@
+# Copyright 2021 The Couler Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import unittest
 
 import couler.argo as couler

--- a/couler/tests/pytorch_step_test.py
+++ b/couler/tests/pytorch_step_test.py
@@ -1,3 +1,16 @@
+# Copyright 2021 The Couler Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from io import StringIO
 
 import yaml

--- a/couler/tests/resource_test.py
+++ b/couler/tests/resource_test.py
@@ -1,3 +1,16 @@
+# Copyright 2021 The Couler Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 
 import pyaml

--- a/couler/tests/run_concurrent_test.py
+++ b/couler/tests/run_concurrent_test.py
@@ -1,3 +1,16 @@
+# Copyright 2021 The Couler Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 
 import pyaml

--- a/couler/tests/secret_test.py
+++ b/couler/tests/secret_test.py
@@ -1,3 +1,16 @@
+# Copyright 2021 The Couler Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import couler.argo as couler
 from couler.core import utils
 from couler.tests.argo_yaml_test import ArgoYamlTest

--- a/couler/tests/step_output_test.py
+++ b/couler/tests/step_output_test.py
@@ -1,3 +1,16 @@
+# Copyright 2021 The Couler Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import couler.argo as couler
 from couler.tests.argo_yaml_test import ArgoYamlTest
 

--- a/couler/tests/tensorflow_step_test.py
+++ b/couler/tests/tensorflow_step_test.py
@@ -1,3 +1,16 @@
+# Copyright 2021 The Couler Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from io import StringIO
 
 import yaml

--- a/couler/tests/test_data/dummy_cluster_config.py
+++ b/couler/tests/test_data/dummy_cluster_config.py
@@ -1,3 +1,17 @@
+# Copyright 2021 The Couler Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 class K8s:
     def __init__(self):
         pass

--- a/couler/tests/utils_test.py
+++ b/couler/tests/utils_test.py
@@ -1,3 +1,16 @@
+# Copyright 2021 The Couler Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import base64
 
 from couler.core import utils

--- a/couler/tests/while_test.py
+++ b/couler/tests/while_test.py
@@ -1,3 +1,16 @@
+# Copyright 2021 The Couler Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import couler.argo as couler
 from couler.tests.argo_yaml_test import ArgoYamlTest
 

--- a/couler/tests/workflow_basic_test.py
+++ b/couler/tests/workflow_basic_test.py
@@ -1,3 +1,16 @@
+# Copyright 2021 The Couler Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import unittest
 from collections import OrderedDict
 

--- a/couler/tests/workflow_basic_test.py
+++ b/couler/tests/workflow_basic_test.py
@@ -53,10 +53,10 @@ class WorkflowBasicTest(ArgoYamlTest):
 
         steps = couler.workflow.get_steps_dict()
         hope_steps = [
-            [OrderedDict({"name": "flip-coin-36", "template": "flip-coin"})],
-            [OrderedDict({"name": "heads-37", "template": "heads"})],
-            [OrderedDict({"name": "tails-38", "template": "tails"})],
-            [OrderedDict({"name": "flip-coin-39", "template": "flip-coin"})],
+            [OrderedDict({"name": "flip-coin-49", "template": "flip-coin"})],
+            [OrderedDict({"name": "heads-50", "template": "heads"})],
+            [OrderedDict({"name": "tails-51", "template": "tails"})],
+            [OrderedDict({"name": "flip-coin-52", "template": "flip-coin"})],
         ]
 
         self.assertEqual(steps, hope_steps)
@@ -69,23 +69,23 @@ class WorkflowBasicTest(ArgoYamlTest):
 
         steps = couler.workflow.get_steps_dict()
         hope_steps = [
-            [OrderedDict({"name": "flip-coin-54", "template": "flip-coin"})],
+            [OrderedDict({"name": "flip-coin-67", "template": "flip-coin"})],
             [
                 OrderedDict(
                     {
-                        "name": "heads-54",
+                        "name": "heads-67",
                         "template": "heads",
-                        "when": "{{steps.flip-coin-54.outputs.result}} == heads",  # noqa: E501
+                        "when": "{{steps.flip-coin-67.outputs.result}} == heads",  # noqa: E501
                     }
                 )
             ],
-            [OrderedDict({"name": "flip-coin-55", "template": "flip-coin"})],
+            [OrderedDict({"name": "flip-coin-68", "template": "flip-coin"})],
             [
                 OrderedDict(
                     {
-                        "name": "tails-55",
+                        "name": "tails-68",
                         "template": "tails",
-                        "when": "{{steps.flip-coin-55.outputs.result}} == tails",  # noqa: E501
+                        "when": "{{steps.flip-coin-68.outputs.result}} == tails",  # noqa: E501
                     }
                 )
             ],
@@ -125,54 +125,54 @@ class WorkflowBasicTest(ArgoYamlTest):
         hope_steps = [
             [
                 OrderedDict(
-                    [("name", "flip-coin-103"), ("template", "flip-coin")]
+                    [("name", "flip-coin-116"), ("template", "flip-coin")]
                 )
             ],
             [
                 OrderedDict(
                     [
-                        ("name", "heads-104"),
+                        ("name", "heads-117"),
                         ("template", "heads"),
                         (
                             "when",
-                            "{{steps.flip-coin-103.outputs.result}} == heads",
+                            "{{steps.flip-coin-116.outputs.result}} == heads",
                         ),
                     ]
                 ),
                 OrderedDict(
                     [
-                        ("name", "tails-107"),
+                        ("name", "tails-120"),
                         ("template", "tails"),
                         (
                             "when",
-                            "{{steps.flip-coin-103.outputs.result}} == tails",
+                            "{{steps.flip-coin-116.outputs.result}} == tails",
                         ),
                     ]
                 ),
             ],
             [
                 OrderedDict(
-                    [("name", "flip-coin-106"), ("template", "flip-coin")]
+                    [("name", "flip-coin-119"), ("template", "flip-coin")]
                 )
             ],
             [
                 OrderedDict(
                     [
-                        ("name", "heads-108"),
+                        ("name", "heads-121"),
                         ("template", "heads"),
                         (
                             "when",
-                            "{{steps.flip-coin-106.outputs.result}} == heads",
+                            "{{steps.flip-coin-119.outputs.result}} == heads",
                         ),
                     ]
                 ),
                 OrderedDict(
                     [
-                        ("name", "tails-109"),
+                        ("name", "tails-122"),
                         ("template", "tails"),
                         (
                             "when",
-                            "{{steps.flip-coin-106.outputs.result}} == tails",
+                            "{{steps.flip-coin-119.outputs.result}} == tails",
                         ),
                     ]
                 ),
@@ -197,17 +197,17 @@ class WorkflowBasicTest(ArgoYamlTest):
         expected = [
             [
                 OrderedDict(
-                    [("name", "flip-coin-178"), ("template", "flip-coin")]
+                    [("name", "flip-coin-191"), ("template", "flip-coin")]
                 )
             ],
             [
                 OrderedDict(
                     [
-                        ("name", "output-message-180"),
+                        ("name", "output-message-193"),
                         ("template", "output-message"),
                         (
                             "when",
-                            "{{steps.flip-coin-178.outputs.result}} > 0.2",
+                            "{{steps.flip-coin-191.outputs.result}} > 0.2",
                         ),
                         (
                             "arguments",
@@ -215,7 +215,7 @@ class WorkflowBasicTest(ArgoYamlTest):
                                 "parameters": [
                                     {
                                         "name": "para-output-message-0",
-                                        "value": '"{{steps.flip-coin-178.outputs.result}}"',  # noqa: E501
+                                        "value": '"{{steps.flip-coin-191.outputs.result}}"',  # noqa: E501
                                     }
                                 ]
                             },

--- a/couler/tests/workflow_validation_utils_test.py
+++ b/couler/tests/workflow_validation_utils_test.py
@@ -1,3 +1,16 @@
+# Copyright 2021 The Couler Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import couler.argo as couler
 from couler.core.workflow_validation_utils import (  # noqa: F401
     validate_workflow_yaml,


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. 
-->
This PR adds copyright licences to all python scripts in the couler project as a fix to the [issue 99](https://github.com/couler-proj/couler/issues/99).

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Documentation and copyright coverage in all python scripts.
Fixes Issue #99 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
No tests. Changes correspond to copyrights only.
Workflow basic test updated to address test failures after adding the copyright license.