### PR TITLE
feat: Support in-cluster configuration in Go submitter

### DIFF
--- a/go/couler/commands/submit.go
+++ b/go/couler/commands/submit.go
@@ -38,11 +38,7 @@ func Submit(cProtoPath, cNamespace, cNamePrefix *C.char) *C.char {
 	if err != nil {
 		return wrapError(fmt.Errorf("failed to get the current user: %w", err))
 	}
-	sub := submitter.ArgoWorkflowSubmitter{
-		Namespace: namespace,
-		// TODO: Support in-cluster configuration
-		KubeConfigPath: filepath.Join(usr.HomeDir, ".kube", "config"),
-	}
+	sub := submitter.New(namespace, filepath.Join(usr.HomeDir, ".kube", "config"))
 	submittedArgoWf, err := sub.Submit(argoWf, true)
 	if err != nil && submittedArgoWf != nil {
 		var errMsg string

--- a/go/couler/submitter/argo_submitter_test.go
+++ b/go/couler/submitter/argo_submitter_test.go
@@ -75,8 +75,8 @@ func TestArgoWorkflowSubmitter(t *testing.T) {
 	assert.NoError(t, err)
 
 	submitter := ArgoWorkflowSubmitter{
-		Namespace:      "argo",
-		KubeConfigPath: filepath.Join(usr.HomeDir, ".kube", "config"),
+		namespace:      "argo",
+		kubeConfigPath: filepath.Join(usr.HomeDir, ".kube", "config"),
 	}
 	finishedArgoWf, err := submitter.Submit(argoWf, true)
 	if err != nil && finishedArgoWf != nil {


### PR DESCRIPTION
Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/couler-proj/couler/blob/master/CODE_OF_CONDUCT.md
  2. Ensure you have added or run the appropriate tests for your PR: https://github.com/couler-proj/couler/blob/master/CONTRIBUTING.md
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. 
-->

Support in-cluster configuration in Go submitter and reuse `submitter.New` instead of previously unnecessarily exporting a struct in https://github.com/couler-proj/couler/pull/170.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->

No.
### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Part of the CI.