### PR TITLE
fix: Do not inject artifacts in args

### DIFF
--- a/couler/core/templates/container.py
+++ b/couler/core/templates/container.py
@@ -193,13 +193,10 @@ class Container(Template):
         if args is not None:
             for i in range(len(args)):
                 o = args[i]
-                if isinstance(o, OutputArtifact):
-                    para_name = o.artifact["name"]
-                    param_full_name = '"{{inputs.artifacts.%s}}"' % para_name
-                else:
+                if not isinstance(o, OutputArtifact):
                     para_name = utils.input_parameter_name(self.name, i)
                     param_full_name = '"{{inputs.parameters.%s}}"' % para_name
-                if param_full_name not in parameters:
-                    parameters.append(param_full_name)
+                    if param_full_name not in parameters:
+                        parameters.append(param_full_name)
 
         return parameters

--- a/couler/tests/test_data/artifact_passing_golden.yaml
+++ b/couler/tests/test_data/artifact_passing_golden.yaml
@@ -79,4 +79,3 @@ spec:
           - 'cat /mnt/t1.txt'
         args:
           - "{{inputs.parameters.para-B-0}}"
-          - "{{inputs.artifacts.output-oss-1c392c25}}"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/couler-proj/couler/blob/master/CODE_OF_CONDUCT.md
  2. Ensure you have added or run the appropriate tests for your PR: https://github.com/couler-proj/couler/blob/master/CONTRIBUTING.md
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. 
-->
With this change, artifacts are not automatically injected in `container.args` or `script.args`. This is causing issues in all of our workflows that pass artifacts since the path of the artifact is getting passed in as arguments to `command`.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Before this change, artifacts were getting injected as args like so:

```yaml
command:
 - python
args:
  - '{{inputs.parameters.para-train-model-0}}' # value is `main.py`
  - '{{inputs.artifacts.output-local-36e25910}}'
```

After this change, the artifact is no longer injected:

```yaml
command:
 - python
args:
  - '{{inputs.parameters.para-train-model-0}}' # value is `main.py`
```

Without this change, any command or script (much like above) that didn't expect an artifact path as an argument failed.

Note that even without [this change](https://github.com/couler-proj/couler/pull/176/files#diff-51425c24d1417abd74391d56dc003f9d958840751a9cffbb887c946b30b94f52R81), all tests pass.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
We made sure the current tests pass and this [use case](https://github.com/onepanelio/python-sdk/blob/8f178d78b8535e8d0d2c3c4244ce3dc33cb080f9/examples/python-defined-workflow.ipynb) for artifact passing is supported.
