### PR TITLE
build: Allow build on dev-* branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,10 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, dev-* ]
   pull_request:
     branches: [ master ]
-  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
We now have centralized control over admin access so `workflow_dispatch` does not seem to work anymore. This PR enables builds on dev branches to facilitate development/debugging.