### PR TITLE
feat: Support IR conversion/submission from Kubeflow steps

### DIFF
--- a/couler/core/proto_repr.py
+++ b/couler/core/proto_repr.py
@@ -59,6 +59,7 @@ def step_repr(
     canned_step_name=None,
     canned_step_args=None,
     resources=None,
+    action=None,
 ):
     assert step_name is not None
     assert tmpl_name is not None
@@ -82,6 +83,8 @@ def step_repr(
         if success_cond is not None and failure_cond is not None:
             pb_step.resource_spec.success_condition = success_cond
             pb_step.resource_spec.failure_condition = failure_cond
+        if action is not None:
+            pb_step.resource_spec.action = action
     else:
         if command is None:
             pb_step.container_spec.command.append("python")

--- a/couler/core/run_templates.py
+++ b/couler/core/run_templates.py
@@ -344,17 +344,19 @@ def run_job(
     step_name=None,
     pool=None,
     env=None,
+    action="create",
     set_owner_reference=True,
 ):
     """
     Create a k8s job. For example, the pi-tmpl template in
     https://github.com/argoproj/argo/blob/master/examples/k8s-jobs.yaml
     :param manifest: YAML specification of the job to be created.
-    :param success_condition: expression for verifying job success.
-    :param failure_condition: expression for verifying job failure.
-    :param timeout: To limit the elapsed time for a workflow in seconds.
-    :param step_name: is only used while developing functions of step zoo.
-    :param env: environmental parameter with a dict types, e.g., {"OS_ENV_1": "OS_ENV_value"}  # noqa: E501
+    :param success_condition: Expression for verifying job success.
+    :param failure_condition: Expression for verifying job failure.
+    :param timeout: The timeout in seconds to limit the elapsed time for a workflow.
+    :param step_name: The step name.
+    :param env: Environmental variables for this step, e.g., {"OS_ENV_1": "OS_ENV_value"}  # noqa: E501
+    :param action: The action to run the manifest. One of: get, create, apply, delete, replace, patch.
     :param set_owner_reference: Whether to set the workflow as the job's owner reference.
         If `True`, the job will be deleted once the workflow is deleted.
     :return: output
@@ -423,6 +425,7 @@ def run_job(
         input=None,
         output=rets,
         manifest=manifest,
+        action=action,
         success_cond=success_condition,
         failure_cond=failure_condition,
     )

--- a/couler/tests/proto_repr_test.py
+++ b/couler/tests/proto_repr_test.py
@@ -143,6 +143,7 @@ spec:
         t = proto_wf.templates[s.tmpl_name]
         self.assertFalse(s.HasField("container_spec"))
         self.assertEqual(s.resource_spec.manifest, manifest)
+        self.assertEqual(s.resource_spec.action, "create")
         self.assertEqual(s.resource_spec.success_condition, success_condition)
         self.assertEqual(s.resource_spec.failure_condition, failure_condition)
         self.assertEqual(len(t.outputs), 3)

--- a/integration_tests/mpi_example.py
+++ b/integration_tests/mpi_example.py
@@ -11,19 +11,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
 import couler.argo as couler
-from couler.argo_submitter import ArgoSubmitter
+from couler.argo_submitter import (
+    _SUBMITTER_IMPL_ENV_VAR_KEY,
+    ArgoSubmitter,
+    _SubmitterImplTypes,
+)
 from couler.steps import mpi
 
 if __name__ == "__main__":
-    couler.config_workflow(timeout=3600, time_to_clean=3600 * 1.5)
+    for impl_type in [_SubmitterImplTypes.GO, _SubmitterImplTypes.PYTHON]:
+        os.environ[_SUBMITTER_IMPL_ENV_VAR_KEY] = impl_type
+        print(
+            "Submitting DAG example workflow via %s implementation" % impl_type
+        )
+        couler.config_workflow(
+            "mpijob-%s" % impl_type.lower(),
+            timeout=3600,
+            time_to_clean=3600 * 1.5,
+        )
 
-    mpi.train(
-        image="alpine:3.6",
-        command=["sh", "-c", 'echo "running"; exit 0'],
-        num_workers=1,
-    )
-    submitter = ArgoSubmitter(namespace="argo")
-    wf = couler.run(submitter=submitter)
-    wf_name = wf["metadata"]["name"]
-    print("Workflow %s has been submitted for MPI example" % wf_name)
+        mpi.train(
+            image="alpine:3.6",
+            command=["sh", "-c", 'echo "running"; exit 0'],
+            num_workers=1,
+        )
+        submitter = ArgoSubmitter(namespace="argo")
+        couler.run(submitter=submitter)


### PR DESCRIPTION
This PR includes the following changes:
* Added missing `action` when converting steps defined via `run_job()` to IR. 
* Added integration test for submitting MPIJob via Go submitter.

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>