### PR TITLE
fix: compatibility when importing proto

### DIFF
--- a/couler/core/states.py
+++ b/couler/core/states.py
@@ -14,8 +14,13 @@
 from collections import OrderedDict
 
 from couler.core import utils
-from couler.core.proto_repr import cleanup_proto_workflow
 from couler.core.templates import Workflow
+
+try:
+    from couler.core.proto_repr import cleanup_proto_workflow
+except Exception:
+    # set cleanup_proto_workflow to an empty function for compatibility
+    cleanup_proto_workflow = lambda: None  # noqa: E731
 
 _sub_steps = None
 # Argo DAG task

--- a/couler/tests/proto_repr_test.py
+++ b/couler/tests/proto_repr_test.py
@@ -15,7 +15,12 @@ import unittest
 
 import couler.argo as couler
 from couler.core import states
-from couler.core.proto_repr import get_default_proto_workflow
+
+try:
+    from couler.core.proto_repr import get_default_proto_workflow
+except Exception:
+    # set cleanup_proto_workflow to an empty function for compatibility
+    cleanup_proto_workflow = lambda: None  # noqa: E731
 
 
 class ProtoReprTest(unittest.TestCase):


### PR DESCRIPTION

### What changes were proposed in this pull request?

Fix compatibility issues when updating from older versions of couler.


### Why are the changes needed?

Some runtime Python environment may have different versions of protobuf Python runtime installed which may cause error.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Current unit tests will cover the changes.