### PR TITLE
feat: Support ServiceAccount for workflows

### DIFF
--- a/couler/core/config.py
+++ b/couler/core/config.py
@@ -23,6 +23,7 @@ def config_workflow(
     time_to_clean=None,
     cluster_config_file=None,
     cron_config=None,
+    service_account=None,
 ):
     """
     Config some workflow-level information.
@@ -32,6 +33,8 @@ def config_workflow(
     :param time_to_clean: time to keep the workflow after completed(seconds).
     :param cluster_config_file: cluster specific config
     :param cron_config: for cron scheduling
+    :param service_account: name of the Kubernetes ServiceAccount which
+        runs this workflow
     :return:
     """
     if name is not None:
@@ -81,6 +84,9 @@ def config_workflow(
             suspend,
             timezone,
         )
+
+    if service_account is not None:
+        states.workflow.service_account = service_account
 
 
 def _config_cron_workflow(

--- a/couler/core/templates/workflow.py
+++ b/couler/core/templates/workflow.py
@@ -38,6 +38,7 @@ class Workflow(object):
         self.cron_config = None
         self.volumes = []
         self.pvcs = []
+        self.service_account = None
 
     def add_template(self, template: Template):
         self.templates.update({template.name: template})
@@ -177,6 +178,9 @@ class Workflow(object):
         if self.clean_ttl is not None:
             workflow_spec["ttlSecondsAfterFinished"] = self.clean_ttl
 
+        if self.service_account is not None:
+            workflow_spec["serviceAccountName"] = self.service_account
+
         # Spec part
         if self.cluster_config is not None and hasattr(
             self.cluster_config, "config_workflow"
@@ -220,3 +224,4 @@ class Workflow(object):
         self.cron_config = None
         self.volumes = []
         self.pvcs = []
+        self.service_account = None

--- a/couler/tests/workflow_basic_test.py
+++ b/couler/tests/workflow_basic_test.py
@@ -226,6 +226,23 @@ class WorkflowBasicTest(ArgoYamlTest):
         ]
         self.assertEqual(steps, expected)
 
+    def test_workflow_service_account(self):
+        self.assertIsNone(couler.workflow.service_account)
+        flip_coin()
+        self.assertNotIn("serviceAccountName", couler.workflow_yaml()["spec"])
+
+        couler.config_workflow(service_account="test-serviceaccount")
+        self.assertEqual(
+            couler.workflow.service_account, "test-serviceaccount"
+        )
+        self.assertEqual(
+            couler.workflow_yaml()["spec"]["serviceAccountName"],
+            "test-serviceaccount",
+        )
+
+        couler._cleanup()
+        self.assertIsNone(couler.workflow.service_account)
+
     def test_workflow_config(self):
         flip_coin()
         tails()


### PR DESCRIPTION
### What changes were proposed in this pull request?

Hi,

This PR adds [ServiceAccount](https://argoproj.github.io/argo-workflows/service-accounts/) in the workflow config. Users can submit workflows with their own k8s ServiceAccuonts now.

```python
couler.config_workflow(
    service_account='dinever',
)
```

![Screen Shot 2021-04-18 at 8 25 36 PM](https://user-images.githubusercontent.com/1311594/115167123-47766200-a084-11eb-92cb-4a3a0cf08392.png)

![Screen Shot 2021-04-18 at 8 25 47 PM](https://user-images.githubusercontent.com/1311594/115167141-54935100-a084-11eb-8042-db2bbe061077.png)


### Why are the changes needed?

Some organizations use non-default service accounts to run Argo workflows for fine-grained permission control.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Unit test