### PR TITLE
feat: Add security context support

### DIFF
--- a/couler/core/templates/workflow.py
+++ b/couler/core/templates/workflow.py
@@ -39,6 +39,7 @@ class Workflow(object):
         self.volumes = []
         self.pvcs = []
         self.service_account = None
+        self.security_context = None
 
     def add_template(self, template: Template):
         self.templates.update({template.name: template})
@@ -115,6 +116,12 @@ class Workflow(object):
         #     d["metadata"]["labels"] = {"couler_job_user": self.user_id}
 
         workflow_spec = {"entrypoint": entrypoint}
+
+        if self.security_context:
+            workflow_spec["securityContext"] = dict()
+            for key, value in self.security_context.items():
+                workflow_spec["securityContext"][key] = value
+
         if self.volumes:
             workflow_spec.update({"volumes": self.volumes})
         if self.pvcs:
@@ -210,6 +217,11 @@ class Workflow(object):
     def config_cron_workflow(self, cron_config):
         self.cron_config = cron_config
 
+    def set_security_context(self, security_context: dict):
+        if not isinstance(security_context, dict):
+            raise TypeError("security_context should be a dict")
+        self.security_context = security_context
+
     def cleanup(self):
         self.name = None
         self.timeout = None
@@ -225,3 +237,4 @@ class Workflow(object):
         self.volumes = []
         self.pvcs = []
         self.service_account = None
+        self.security_context = None

--- a/integration_tests/flip_coin_security_context_example.py
+++ b/integration_tests/flip_coin_security_context_example.py
@@ -45,14 +45,14 @@ def tails():
 
 
 if __name__ == "__main__":
-    for impl_type in [_SubmitterImplTypes.GO, _SubmitterImplTypes.PYTHON]:
+    for impl_type in [_SubmitterImplTypes.PYTHON]:
         os.environ[_SUBMITTER_IMPL_ENV_VAR_KEY] = impl_type
         print(
             "Submitting flip coin example workflow via %s implementation"
             % impl_type
         )
         couler.config_workflow(
-            name="flip-coin-%s" % impl_type.lower(),
+            name="flip-coin-sc-%s" % impl_type.lower(),
             timeout=3600,
             time_to_clean=3600 * 1.5,
         )

--- a/integration_tests/flip_coin_security_context_example.py
+++ b/integration_tests/flip_coin_security_context_example.py
@@ -1,0 +1,68 @@
+# Copyright 2021 The Couler Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import couler.argo as couler
+from couler.argo_submitter import (
+    _SUBMITTER_IMPL_ENV_VAR_KEY,
+    ArgoSubmitter,
+    _SubmitterImplTypes,
+)
+
+
+def random_code():
+    import random
+
+    res = "heads" if random.randint(0, 1) == 0 else "tails"
+    print(res)
+
+
+def flip_coin():
+    return couler.run_script(image="python:alpine3.6", source=random_code)
+
+
+def heads():
+    return couler.run_container(
+        image="alpine:3.6", command=["sh", "-c", 'echo "it was heads"']
+    )
+
+
+def tails():
+    return couler.run_container(
+        image="alpine:3.6", command=["sh", "-c", 'echo "it was tails"']
+    )
+
+
+if __name__ == "__main__":
+    for impl_type in [_SubmitterImplTypes.GO, _SubmitterImplTypes.PYTHON]:
+        os.environ[_SUBMITTER_IMPL_ENV_VAR_KEY] = impl_type
+        print(
+            "Submitting flip coin example workflow via %s implementation"
+            % impl_type
+        )
+        couler.config_workflow(
+            name="flip-coin-%s" % impl_type.lower(),
+            timeout=3600,
+            time_to_clean=3600 * 1.5,
+        )
+        result = flip_coin()
+        couler.when(couler.equal(result, "heads"), lambda: heads())
+        couler.when(couler.equal(result, "tails"), lambda: tails())
+
+        couler.states.workflow.set_security_context(
+            security_context={"seLinuxOptions": {"level": "s0:c123,c456"}}
+        )
+
+        submitter = ArgoSubmitter(namespace="argo")
+        couler.run(submitter=submitter)

--- a/scripts/integration_tests.sh
+++ b/scripts/integration_tests.sh
@@ -17,6 +17,7 @@ python -m integration_tests.mpi_example
 python -m integration_tests.dag_example
 python -m integration_tests.dag_depends_example
 python -m integration_tests.flip_coin_example
+python -m integration_tests.flip_coin_security_context_example
 python -m integration_tests.memoization_example
 
 # Validate workflow statuses


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR adds support for specifying a workflow-level [`securityContext`](https://argoproj.github.io/argo-workflows/fields/#podsecuritycontext) to any argo workflow.

### Why are the changes needed?
Many kubernetes clusters enforce a pod security policy. This requires argo workflows to include the appropriate workflow-level [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) in order to run with the appropriate permissions.

```python
couler.states.workflow.set_security_context(security_context={
    "fsGroup": 2000,
    "runAsNonRoot": True,
    "runAsUser": 1000,
})
```

```console
☸️  minikube (argo) via 🐍 v3.8.5 (venv) 
🚩 python3 main.py
INFO:root:Found local kubernetes config. Initialized with kube_config.
INFO:root:Checking workflow name/generatedName main-
INFO:root:Submitting workflow to Argo
INFO:root:Workflow main-g246r has been submitted in "argo" namespace!

☸️  minikube (argo) via 🐍 v3.8.5 (venv) 
🚩 argo logs -f main-g246r
main-g246r-2200494999: tails
main-g246r-2776786118: TAILS!!!

☸️  minikube (argo) via 🐍 v3.8.5 (venv) 
🚩 kubectl get wf main-g246r -oyaml | grep -A2 securityContext
        f:securityContext:
          .: {}
          f:seLinuxOptions:
--
  securityContext:
    seLinuxOptions:
      level: s0:c123,c456
```

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
- Unit tests
- Integration tests

Closes #200