### PR TITLE
fix: Volume_claim to dynamic

### DIFF
--- a/couler/core/templates/volume_claim.py
+++ b/couler/core/templates/volume_claim.py
@@ -16,12 +16,8 @@ from typing import List
 
 
 class VolumeClaimTemplate(object):
-    def __init__(
-        self,
-        claim_name: str,
-        access_modes: List[str] = ["ReadWriteOnce"],
-        size: str = "1Gi",
-    ):
+    def __init__(self, claim_name: str, access_modes: List[str], size: str):
+
         self.claim_name = claim_name
         self.access_modes = access_modes
         self.size = size

--- a/couler/tests/argo_test.py
+++ b/couler/tests/argo_test.py
@@ -149,7 +149,7 @@ class ArgoTest(ArgoBaseTestCase):
         couler._cleanup()
 
     def test_run_container_with_workflow_volume(self):
-        pvc = VolumeClaimTemplate("workdir")
+        pvc = VolumeClaimTemplate("workdir", ["ReadWriteOnce"], "1Gi")
         volume_mount = VolumeMount("workdir", "/mnt/vol")
         couler.create_workflow_volume(pvc)
         couler.run_container(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/couler-proj/couler/blob/master/CODE_OF_CONDUCT.md
  2. Ensure you have added or run the appropriate tests for your PR: https://github.com/couler-proj/couler/blob/master/CONTRIBUTING.md
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. 
-->
The proposal would make the `VolumeClaimTemplate`s size and `accessModes` dynamic by letting the user input them so they would not be hardcoded.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
#210 
Working on a workflow I noticed that my workflow would require the `accessModes` to be `ReadWriteMany`, not `ReadWriteOnce`. `ReadWriteOnce` was hardcoded, I thought that it would be better if the workflow creator could set it the way she/he needs it. Same for the `size`.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->

Users would have to write 3 arguments to the VolumeClaimTemplate instead of one. 

Previous version:
`volume = VolumeClaimTemplate("workdir")`

Updated version:
`volume = VolumeClaimTemplate("workdir", ['ReadWriteMany'], '1Gi')`

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
The testing was done by abiding [Coulers instructions](https://github.com/couler-proj/couler/blob/0b33ac61588d8dbfe4ccbdf618de2572cf776ce2/CONTRIBUTING.md)

I added a new scripts/integration_tests.Unix.sh. 
Because I encountered the following [problem](https://stackoverflow.com/questions/29045140/env-bash-r-no-such-file-or-directory/29045187) the solution is in the link also.
