### PR TITLE
feat: Implemented `envFrom` field for containers + saving given client config + automatic naming salt for workflow names

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,5 +1,5 @@
 [settings]
 multi_line_output=3
 line_length=79
-known_third_party=docker,google,kubernetes,pyaml,setuptools,yaml
+known_third_party=docker,google,kubernetes,pyaml,setuptools,strgen,stringcase,yaml
 include_trailing_comma=True

--- a/couler/argo.py
+++ b/couler/argo.py
@@ -61,7 +61,7 @@ def run(submitter=None):
     """
     states._enable_print_yaml = False
 
-    if submitter is None and ArgoSubmitter.default_submitter is None:
+    if submitter is None and ArgoSubmitter._default_submitter is None:
         raise ValueError(
             "The input submitter is None and default submitter was not set."
         )
@@ -78,7 +78,7 @@ def run(submitter=None):
         else:
             raise ValueError("Only ArgoSubmitter is supported currently.")
     else:
-        res = ArgoSubmitter.default_submitter.submit(wf, secrets=secrets)
+        res = ArgoSubmitter._default_submitter.submit(wf, secrets=secrets)
 
     # Clean up the saved states of the workflow since we made a copy of
     # the workflow above and no longer need the original reference. This

--- a/couler/argo.py
+++ b/couler/argo.py
@@ -86,6 +86,17 @@ def run(submitter=None):
     _cleanup()
     return res
 
+def set_default_submitter(submitter=None):
+    """
+    Config couler defaults.
+    :param submitter: default submitter to use when submitting workflows
+    :return:
+    """
+    if submitter is not None:
+        if not isinstance(submitter, ArgoSubmitter):
+            raise ValueError("Only ArgoSubmitter is supported currently.")
+        ArgoSubmitter._default_submitter = submitter
+
 
 def delete(
     name,

--- a/couler/argo.py
+++ b/couler/argo.py
@@ -86,6 +86,7 @@ def run(submitter=None):
     _cleanup()
     return res
 
+
 def set_default_submitter(submitter=None):
     """
     Config couler defaults.

--- a/couler/argo.py
+++ b/couler/argo.py
@@ -62,7 +62,9 @@ def run(submitter=None):
     states._enable_print_yaml = False
 
     if submitter is None and ArgoSubmitter.default_submitter is None:
-        raise ValueError("The input submitter is None and default submitter was not set.")
+        raise ValueError(
+            "The input submitter is None and default submitter was not set."
+        )
     wf = workflow_yaml()
     secrets = states._secrets.values()
     validate_workflow_yaml(wf)
@@ -86,14 +88,14 @@ def run(submitter=None):
 
 
 def delete(
-        name,
-        namespace="default",
-        config_file=None,
-        context=None,
-        client_configuration=None,
-        persist_config=True,
-        grace_period_seconds=5,
-        propagation_policy="Background",
+    name,
+    namespace="default",
+    config_file=None,
+    context=None,
+    client_configuration=None,
+    persist_config=True,
+    grace_period_seconds=5,
+    propagation_policy="Background",
 ):
     try:
         config.load_kube_config(
@@ -167,13 +169,13 @@ def create_local_artifact(path, is_global=False):
 
 
 def create_oss_artifact(
-        path,
-        bucket=None,
-        accesskey_id=None,
-        accesskey_secret=None,
-        key=None,
-        endpoint=None,
-        is_global=False,
+    path,
+    bucket=None,
+    accesskey_id=None,
+    accesskey_secret=None,
+    key=None,
+    endpoint=None,
+    is_global=False,
 ):
     """
     Configure the object as OssArtifact
@@ -199,13 +201,13 @@ def create_oss_artifact(
 
 
 def create_s3_artifact(
-        path,
-        bucket=None,
-        accesskey_id=None,
-        accesskey_secret=None,
-        key=None,
-        endpoint=None,
-        is_global=False,
+    path,
+    bucket=None,
+    accesskey_id=None,
+    accesskey_secret=None,
+    key=None,
+    endpoint=None,
+    is_global=False,
 ):
     """
     Configure the object as S3Artifact

--- a/couler/argo.py
+++ b/couler/argo.py
@@ -76,7 +76,7 @@ def run(submitter=None):
         else:
             raise ValueError("Only ArgoSubmitter is supported currently.")
     else:
-        res = states.default_submitter.submit(wf, secrets=secrets)
+        res = ArgoSubmitter.default_submitter.submit(wf, secrets=secrets)
 
     # Clean up the saved states of the workflow since we made a copy of
     # the workflow above and no longer need the original reference. This

--- a/couler/argo.py
+++ b/couler/argo.py
@@ -21,7 +21,7 @@ from kubernetes import config
 
 from couler.argo_submitter import ArgoSubmitter
 from couler.core import states  # noqa: F401
-from couler.core.config import config_workflow  # noqa: F401
+from couler.core.config import config_defaults, config_workflow  # noqa: F401
 from couler.core.constants import *  # noqa: F401, F403
 from couler.core.constants import WorkflowCRD
 from couler.core.run_templates import (  # noqa: F401

--- a/couler/argo_submitter.py
+++ b/couler/argo_submitter.py
@@ -34,7 +34,7 @@ class _SubmitterImplTypes(object):
 class ArgoSubmitter(object):
     """A submitter which submits a workflow to Argo"""
 
-    default_submitter = None
+    _default_submitter = None
 
     def __init__(
         self,
@@ -179,4 +179,4 @@ class ArgoSubmitter(object):
         if submitter is not None:
             if not isinstance(submitter, ArgoSubmitter):
                 raise ValueError("Only ArgoSubmitter is supported currently.")
-            cls.default_submitter = submitter
+            cls._default_submitter = submitter

--- a/couler/argo_submitter.py
+++ b/couler/argo_submitter.py
@@ -74,7 +74,7 @@ class ArgoSubmitter(object):
                     "Initialized with kube_config."
                 )
                 if client_configuration is not None:
-                    logging.info("Setting default k8s to given client config.")
+                    logging.info("Setting default k8s client config as provided")
                     k8s_client.Configuration.set_default(client_configuration)
             except Exception:
                 logging.info(

--- a/couler/argo_submitter.py
+++ b/couler/argo_submitter.py
@@ -37,21 +37,21 @@ class ArgoSubmitter(object):
     _default_submitter = None
 
     def __init__(
-        self,
-        namespace="default",
-        config_file=None,
-        context=None,
-        client_configuration=None,
-        persist_config=True,
+            self,
+            namespace="default",
+            config_file=None,
+            context=None,
+            client_configuration=None,
+            persist_config=True,
     ):
         logging.basicConfig(level=logging.INFO)
         self.namespace = namespace
         logging.info("Argo submitter namespace: %s" % self.namespace)
         self.go_impl = (
-            os.environ.get(
-                _SUBMITTER_IMPL_ENV_VAR_KEY, _SubmitterImplTypes.PYTHON
-            )
-            == _SubmitterImplTypes.GO
+                os.environ.get(
+                    _SUBMITTER_IMPL_ENV_VAR_KEY, _SubmitterImplTypes.PYTHON
+                )
+                == _SubmitterImplTypes.GO
         )
         if self.go_impl:
             from ctypes import c_char_p, cdll
@@ -62,7 +62,7 @@ class ArgoSubmitter(object):
             self.go_submitter.Submit.restype = c_char_p
 
             with tempfile.NamedTemporaryFile(
-                dir="/tmp", delete=False, mode="wb"
+                    dir="/tmp", delete=False, mode="wb"
             ) as tmp_file:
                 self.proto_path = tmp_file.name
                 proto_wf = get_default_proto_workflow()
@@ -168,15 +168,3 @@ class ArgoSubmitter(object):
         return self._core_api_client.create_namespaced_secret(  # noqa: E501
             self.namespace, secret_yaml
         )
-
-    @classmethod
-    def set_default(cls, submitter=None):
-        """
-        Config couler defaults.
-        :param submitter: default submitter to use when submitting workflows
-        :return:
-        """
-        if submitter is not None:
-            if not isinstance(submitter, ArgoSubmitter):
-                raise ValueError("Only ArgoSubmitter is supported currently.")
-            cls._default_submitter = submitter

--- a/couler/argo_submitter.py
+++ b/couler/argo_submitter.py
@@ -37,21 +37,21 @@ class ArgoSubmitter(object):
     _default_submitter = None
 
     def __init__(
-            self,
-            namespace="default",
-            config_file=None,
-            context=None,
-            client_configuration=None,
-            persist_config=True,
+        self,
+        namespace="default",
+        config_file=None,
+        context=None,
+        client_configuration=None,
+        persist_config=True,
     ):
         logging.basicConfig(level=logging.INFO)
         self.namespace = namespace
         logging.info("Argo submitter namespace: %s" % self.namespace)
         self.go_impl = (
-                os.environ.get(
-                    _SUBMITTER_IMPL_ENV_VAR_KEY, _SubmitterImplTypes.PYTHON
-                )
-                == _SubmitterImplTypes.GO
+            os.environ.get(
+                _SUBMITTER_IMPL_ENV_VAR_KEY, _SubmitterImplTypes.PYTHON
+            )
+            == _SubmitterImplTypes.GO
         )
         if self.go_impl:
             from ctypes import c_char_p, cdll
@@ -62,7 +62,7 @@ class ArgoSubmitter(object):
             self.go_submitter.Submit.restype = c_char_p
 
             with tempfile.NamedTemporaryFile(
-                    dir="/tmp", delete=False, mode="wb"
+                dir="/tmp", delete=False, mode="wb"
             ) as tmp_file:
                 self.proto_path = tmp_file.name
                 proto_wf = get_default_proto_workflow()

--- a/couler/argo_submitter.py
+++ b/couler/argo_submitter.py
@@ -33,24 +33,25 @@ class _SubmitterImplTypes(object):
 # TODO: some k8s common parts can move to another file later.
 class ArgoSubmitter(object):
     """A submitter which submits a workflow to Argo"""
+
     default_submitter = None
 
     def __init__(
-            self,
-            namespace="default",
-            config_file=None,
-            context=None,
-            client_configuration=None,
-            persist_config=True,
+        self,
+        namespace="default",
+        config_file=None,
+        context=None,
+        client_configuration=None,
+        persist_config=True,
     ):
         logging.basicConfig(level=logging.INFO)
         self.namespace = namespace
         logging.info("Argo submitter namespace: %s" % self.namespace)
         self.go_impl = (
-                os.environ.get(
-                    _SUBMITTER_IMPL_ENV_VAR_KEY, _SubmitterImplTypes.PYTHON
-                )
-                == _SubmitterImplTypes.GO
+            os.environ.get(
+                _SUBMITTER_IMPL_ENV_VAR_KEY, _SubmitterImplTypes.PYTHON
+            )
+            == _SubmitterImplTypes.GO
         )
         if self.go_impl:
             from ctypes import c_char_p, cdll
@@ -61,7 +62,7 @@ class ArgoSubmitter(object):
             self.go_submitter.Submit.restype = c_char_p
 
             with tempfile.NamedTemporaryFile(
-                    dir="/tmp", delete=False, mode="wb"
+                dir="/tmp", delete=False, mode="wb"
             ) as tmp_file:
                 self.proto_path = tmp_file.name
                 proto_wf = get_default_proto_workflow()
@@ -76,7 +77,9 @@ class ArgoSubmitter(object):
                     "Initialized with kube_config."
                 )
                 if client_configuration is not None:
-                    logging.info("Setting default k8s client config as provided")
+                    logging.info(
+                        "Setting default k8s client config as provided"
+                    )
                     k8s_client.Configuration.set_default(client_configuration)
             except Exception:
                 logging.info(

--- a/couler/argo_submitter.py
+++ b/couler/argo_submitter.py
@@ -73,6 +73,8 @@ class ArgoSubmitter(object):
                     "Found local kubernetes config. "
                     "Initialized with kube_config."
                 )
+                if client_configuration is not None:
+                    k8s_client.Configuration.set_default(client_configuration)
             except Exception:
                 logging.info(
                     "Cannot find local k8s config. "

--- a/couler/argo_submitter.py
+++ b/couler/argo_submitter.py
@@ -74,8 +74,8 @@ class ArgoSubmitter(object):
                     "Initialized with kube_config."
                 )
                 if client_configuration is not None:
+                    logging.info("Setting default k8s to given client config.")
                     k8s_client.Configuration.set_default(client_configuration)
-                    logging.info("Default k8s client config set.")
             except Exception:
                 logging.info(
                     "Cannot find local k8s config. "

--- a/couler/argo_submitter.py
+++ b/couler/argo_submitter.py
@@ -75,6 +75,7 @@ class ArgoSubmitter(object):
                 )
                 if client_configuration is not None:
                     k8s_client.Configuration.set_default(client_configuration)
+                    logging.info("Default k8s client config set.")
             except Exception:
                 logging.info(
                     "Cannot find local k8s config. "

--- a/couler/core/config.py
+++ b/couler/core/config.py
@@ -25,7 +25,7 @@ def config_defaults(name_salter=None, service_account: str = None):
     :return:
     """
     if name_salter is not None:
-        states.workflow_name_salter = name_salter
+        states._workflow_name_salter = name_salter
 
     if service_account is not None:
         states.default_service_account = service_account
@@ -53,7 +53,7 @@ def config_workflow(
     :return:
     """
     if name is not None:
-        states.workflow.name = states.workflow_name_salter(name)
+        states.workflow.name = states._workflow_name_salter(name)
 
     if user_id is not None:
         states.workflow.user_id = user_id

--- a/couler/core/config.py
+++ b/couler/core/config.py
@@ -16,20 +16,36 @@ from collections import OrderedDict
 from couler.core import states, utils
 
 
+def config_defaults(
+        name_salter=None,
+        service_account: str = None
+):
+    """
+    Config couler defaults.
+    :param name_salter: function to salt workflow names.
+    :param service_account: name of the default Kubernetes
+        ServiceAccount with which to run workflows
+    :return:
+    """
+    if name_salter is not None:
+        states.workflow_name_salter = name_salter
+
+    if service_account is not None:
+        states.default_service_account = service_account
+
+
 def config_workflow(
-    name=None,
-    name_salter=None,
-    user_id=None,
-    timeout=None,
-    time_to_clean=None,
-    cluster_config_file=None,
-    cron_config=None,
-    service_account=None,
+        name=None,
+        user_id=None,
+        timeout=None,
+        time_to_clean=None,
+        cluster_config_file=None,
+        cron_config=None,
+        service_account=None,
 ):
     """
     Config some workflow-level information.
     :param name: name of the workflow.
-    :param name_salter: function to salt workflow names.
     :param user_id: user information.
     :param timeout: maximum running time(seconds).
     :param time_to_clean: time to keep the workflow after completed(seconds).
@@ -39,9 +55,6 @@ def config_workflow(
         runs this workflow
     :return:
     """
-    if name_salter is not None:
-        states.workflow_name_salter = name_salter
-
     if name is not None:
         states.workflow.name = states.workflow_name_salter(name)
 
@@ -90,18 +103,18 @@ def config_workflow(
             timezone,
         )
 
-    if service_account is not None:
-        states.workflow.service_account = service_account
+    states.workflow.service_account = \
+        service_account if service_account is not None else states.default_service_account
 
 
 def _config_cron_workflow(
-    schedule,
-    concurrency_policy='"Allow"',  # Default to "Allow"
-    successful_jobs_history_limit=3,  # Default 3
-    failed_jobs_history_limit=1,  # Default 1
-    starting_deadline_seconds=10,
-    suspend="false",
-    timezone="Asia/Shanghai",  # Default to Beijing time
+        schedule,
+        concurrency_policy='"Allow"',  # Default to "Allow"
+        successful_jobs_history_limit=3,  # Default 3
+        failed_jobs_history_limit=1,  # Default 1
+        starting_deadline_seconds=10,
+        suspend="false",
+        timezone="Asia/Shanghai",  # Default to Beijing time
 ):
     """
     Config the CronWorkflow, see example

--- a/couler/core/config.py
+++ b/couler/core/config.py
@@ -18,6 +18,7 @@ from couler.core import states, utils
 
 def config_workflow(
     name=None,
+    name_salter=None,
     user_id=None,
     timeout=None,
     time_to_clean=None,
@@ -28,6 +29,7 @@ def config_workflow(
     """
     Config some workflow-level information.
     :param name: name of the workflow.
+    :param name_salter: function to salt workflow names.
     :param user_id: user information.
     :param timeout: maximum running time(seconds).
     :param time_to_clean: time to keep the workflow after completed(seconds).
@@ -37,8 +39,11 @@ def config_workflow(
         runs this workflow
     :return:
     """
+    if name_salter is not None:
+        states.workflow_name_salter = name_salter
+
     if name is not None:
-        states.workflow.name = name
+        states.workflow.name = states.workflow_name_salter(name)
 
     if user_id is not None:
         states.workflow.user_id = user_id

--- a/couler/core/config.py
+++ b/couler/core/config.py
@@ -16,10 +16,7 @@ from collections import OrderedDict
 from couler.core import states, utils
 
 
-def config_defaults(
-        name_salter=None,
-        service_account: str = None
-):
+def config_defaults(name_salter=None, service_account: str = None):
     """
     Config couler defaults.
     :param name_salter: function to salt workflow names.
@@ -35,13 +32,13 @@ def config_defaults(
 
 
 def config_workflow(
-        name=None,
-        user_id=None,
-        timeout=None,
-        time_to_clean=None,
-        cluster_config_file=None,
-        cron_config=None,
-        service_account=None,
+    name=None,
+    user_id=None,
+    timeout=None,
+    time_to_clean=None,
+    cluster_config_file=None,
+    cron_config=None,
+    service_account=None,
 ):
     """
     Config some workflow-level information.
@@ -103,18 +100,21 @@ def config_workflow(
             timezone,
         )
 
-    states.workflow.service_account = \
-        service_account if service_account is not None else states.default_service_account
+    states.workflow.service_account = (
+        service_account
+        if service_account is not None
+        else states.default_service_account
+    )
 
 
 def _config_cron_workflow(
-        schedule,
-        concurrency_policy='"Allow"',  # Default to "Allow"
-        successful_jobs_history_limit=3,  # Default 3
-        failed_jobs_history_limit=1,  # Default 1
-        starting_deadline_seconds=10,
-        suspend="false",
-        timezone="Asia/Shanghai",  # Default to Beijing time
+    schedule,
+    concurrency_policy='"Allow"',
+    successful_jobs_history_limit=3,  # Default 3
+    failed_jobs_history_limit=1,  # Default 1
+    starting_deadline_seconds=10,
+    suspend="false",
+    timezone="Asia/Shanghai",
 ):
     """
     Config the CronWorkflow, see example

--- a/couler/core/run_templates.py
+++ b/couler/core/run_templates.py
@@ -201,6 +201,7 @@ def run_container(
     output=None,
     input=None,
     env=None,
+    env_from=None,
     secret=None,
     resources=None,
     timeout=None,
@@ -213,8 +214,7 @@ def run_container(
     volume_mounts=None,
     working_dir=None,
     node_selector=None,
-    cache=None,
-):
+    cache=None):
     """
     Generate an Argo container template.  For example, the template whalesay
     in https://github.com/argoproj/argo/tree/master/examples#hello-world.
@@ -297,6 +297,7 @@ def run_container(
             command=command,
             args=args,
             env=env,
+            env_from=env_from,
             secret=states.get_secret(secret),
             resources=resources,
             image_pull_policy=image_pull_policy,

--- a/couler/core/run_templates.py
+++ b/couler/core/run_templates.py
@@ -214,7 +214,8 @@ def run_container(
     volume_mounts=None,
     working_dir=None,
     node_selector=None,
-    cache=None):
+    cache=None,
+    parallelism=None):
     """
     Generate an Argo container template.  For example, the template whalesay
     in https://github.com/argoproj/argo/tree/master/examples#hello-world.
@@ -312,6 +313,7 @@ def run_container(
             working_dir=working_dir,
             node_selector=node_selector,
             cache=cache,
+            parallelism=parallelism
         )
         states.workflow.add_template(template)
 

--- a/couler/core/run_templates.py
+++ b/couler/core/run_templates.py
@@ -215,7 +215,8 @@ def run_container(
     working_dir=None,
     node_selector=None,
     cache=None,
-    parallelism=None):
+    parallelism=None,
+):
     """
     Generate an Argo container template.  For example, the template whalesay
     in https://github.com/argoproj/argo/tree/master/examples#hello-world.
@@ -313,7 +314,7 @@ def run_container(
             working_dir=working_dir,
             node_selector=node_selector,
             cache=cache,
-            parallelism=parallelism
+            parallelism=parallelism,
         )
         states.workflow.add_template(template)
 

--- a/couler/core/states.py
+++ b/couler/core/states.py
@@ -35,6 +35,7 @@ def default_workflow_name_salter(name):
 
 
 workflow_name_salter = default_workflow_name_salter
+default_service_account = None
 
 _sub_steps = None
 # Argo DAG task

--- a/couler/core/states.py
+++ b/couler/core/states.py
@@ -25,16 +25,16 @@ except Exception:
     # set cleanup_proto_workflow to an empty function for compatibility
     cleanup_proto_workflow = lambda: None  # noqa: E731
 
-name_salt = StringGenerator(r"[\c\d]{8}")
+_name_salt = StringGenerator(r"[\c\d]{8}")
 
 
 def default_workflow_name_salter(name):
     # The maximum length of a workflow name derives from the 
     # maximum k8s resource name length (workflows are custom resources).
-    return "{0}-{1}".format(spinalcase(name), name_salt.render())[:62]
+    return "{0}-{1}".format(spinalcase(name), _name_salt.render())[:62]
 
 
-workflow_name_salter = default_workflow_name_salter
+_workflow_name_salter = default_workflow_name_salter
 default_service_account = None
 
 _sub_steps = None

--- a/couler/core/states.py
+++ b/couler/core/states.py
@@ -13,6 +13,9 @@
 
 from collections import OrderedDict
 
+from strgen import StringGenerator
+from stringcase import spinalcase
+
 from couler.core import utils
 from couler.core.templates import Workflow
 
@@ -21,6 +24,17 @@ try:
 except Exception:
     # set cleanup_proto_workflow to an empty function for compatibility
     cleanup_proto_workflow = lambda: None  # noqa: E731
+
+name_salt = StringGenerator(r"[\c\d]{8}")
+
+
+def default_workflow_name_salter(name):
+    return "{0}-{1}".format(
+        spinalcase(name),
+        name_salt.render())[:62]
+
+
+workflow_name_salter = default_workflow_name_salter
 
 _sub_steps = None
 # Argo DAG task

--- a/couler/core/states.py
+++ b/couler/core/states.py
@@ -29,6 +29,8 @@ name_salt = StringGenerator(r"[\c\d]{8}")
 
 
 def default_workflow_name_salter(name):
+    # The maximum length of a workflow name derives from the 
+    # maximum k8s resource name length (workflows are custom resources).
     return "{0}-{1}".format(spinalcase(name), name_salt.render())[:62]
 
 

--- a/couler/core/states.py
+++ b/couler/core/states.py
@@ -29,9 +29,7 @@ name_salt = StringGenerator(r"[\c\d]{8}")
 
 
 def default_workflow_name_salter(name):
-    return "{0}-{1}".format(
-        spinalcase(name),
-        name_salt.render())[:62]
+    return "{0}-{1}".format(spinalcase(name), name_salt.render())[:62]
 
 
 workflow_name_salter = default_workflow_name_salter

--- a/couler/core/states.py
+++ b/couler/core/states.py
@@ -29,7 +29,7 @@ _name_salt = StringGenerator(r"[\c\d]{8}")
 
 
 def default_workflow_name_salter(name):
-    # The maximum length of a workflow name derives from the 
+    # The maximum length of a workflow name derives from the
     # maximum k8s resource name length (workflows are custom resources).
     return "{0}-{1}".format(spinalcase(name), _name_salt.render())[:62]
 

--- a/couler/core/templates/container.py
+++ b/couler/core/templates/container.py
@@ -24,27 +24,28 @@ from couler.core.templates.template import Template
 
 class Container(Template):
     def __init__(
-        self,
-        name,
-        image,
-        command,
-        args=None,
-        env=None,
-        secret=None,
-        resources=None,
-        image_pull_policy=None,
-        retry=None,
-        timeout=None,
-        pool=None,
-        output=None,
-        input=None,
-        enable_ulogfs=True,
-        daemon=False,
-        volume_mounts=None,
-        working_dir=None,
-        node_selector=None,
-        volumes=None,
-        cache=None,
+            self,
+            name,
+            image,
+            command,
+            args=None,
+            env=None,
+            env_from=None,
+            secret=None,
+            resources=None,
+            image_pull_policy=None,
+            retry=None,
+            timeout=None,
+            pool=None,
+            output=None,
+            input=None,
+            enable_ulogfs=True,
+            daemon=False,
+            volume_mounts=None,
+            working_dir=None,
+            node_selector=None,
+            volumes=None,
+            cache=None,
     ):
         Template.__init__(
             self,
@@ -62,6 +63,7 @@ class Container(Template):
         self.command = utils.make_list_if_not(command)
         self.args = args
         self.env = env
+        self.env_from = env_from
         self.secret = secret
         self.resources = resources
         self.image_pull_policy = image_pull_policy
@@ -126,8 +128,8 @@ class Container(Template):
 
         # Container
         if (
-            not utils.gpu_requested(self.resources)
-            and states._overwrite_nvidia_gpu_envs
+                not utils.gpu_requested(self.resources)
+                and states._overwrite_nvidia_gpu_envs
         ):
             if self.env is None:
                 self.env = {}
@@ -166,6 +168,8 @@ class Container(Template):
                 container["env"] = self.secret.to_env_list()
             else:
                 container["env"].extend(self.secret.to_env_list())
+        if self.env_from is not None:
+            container["envFrom"] = self.env_from
         if self.resources is not None:
             container["resources"] = {
                 "requests": self.resources,

--- a/couler/core/templates/container.py
+++ b/couler/core/templates/container.py
@@ -24,29 +24,29 @@ from couler.core.templates.template import Template
 
 class Container(Template):
     def __init__(
-            self,
-            name,
-            image,
-            command,
-            args=None,
-            env=None,
-            env_from=None,
-            secret=None,
-            resources=None,
-            image_pull_policy=None,
-            retry=None,
-            timeout=None,
-            pool=None,
-            output=None,
-            input=None,
-            enable_ulogfs=True,
-            daemon=False,
-            volume_mounts=None,
-            working_dir=None,
-            node_selector=None,
-            volumes=None,
-            cache=None,
-            parallelism=None
+        self,
+        name,
+        image,
+        command,
+        args=None,
+        env=None,
+        env_from=None,
+        secret=None,
+        resources=None,
+        image_pull_policy=None,
+        retry=None,
+        timeout=None,
+        pool=None,
+        output=None,
+        input=None,
+        enable_ulogfs=True,
+        daemon=False,
+        volume_mounts=None,
+        working_dir=None,
+        node_selector=None,
+        volumes=None,
+        cache=None,
+        parallelism=None,
     ):
         Template.__init__(
             self,
@@ -59,7 +59,7 @@ class Container(Template):
             enable_ulogfs=enable_ulogfs,
             daemon=daemon,
             cache=cache,
-            parallelism=parallelism
+            parallelism=parallelism,
         )
         self.image = image
         self.command = utils.make_list_if_not(command)
@@ -130,8 +130,8 @@ class Container(Template):
 
         # Container
         if (
-                not utils.gpu_requested(self.resources)
-                and states._overwrite_nvidia_gpu_envs
+            not utils.gpu_requested(self.resources)
+            and states._overwrite_nvidia_gpu_envs
         ):
             if self.env is None:
                 self.env = {}

--- a/couler/core/templates/container.py
+++ b/couler/core/templates/container.py
@@ -46,6 +46,7 @@ class Container(Template):
             node_selector=None,
             volumes=None,
             cache=None,
+            parallelism=None
     ):
         Template.__init__(
             self,
@@ -58,6 +59,7 @@ class Container(Template):
             enable_ulogfs=enable_ulogfs,
             daemon=daemon,
             cache=cache,
+            parallelism=parallelism
         )
         self.image = image
         self.command = utils.make_list_if_not(command)

--- a/couler/core/templates/template.py
+++ b/couler/core/templates/template.py
@@ -18,17 +18,17 @@ from couler.core import utils
 
 class Template(object):
     def __init__(
-            self,
-            name,
-            output=None,
-            input=None,
-            timeout=None,
-            retry=None,
-            pool=None,
-            enable_ulogfs=True,
-            daemon=False,
-            cache=None,
-            parallelism=None
+        self,
+        name,
+        output=None,
+        input=None,
+        timeout=None,
+        retry=None,
+        pool=None,
+        enable_ulogfs=True,
+        daemon=False,
+        cache=None,
+        parallelism=None,
     ):
         self.name = name
         self.output = output

--- a/couler/core/templates/template.py
+++ b/couler/core/templates/template.py
@@ -18,16 +18,17 @@ from couler.core import utils
 
 class Template(object):
     def __init__(
-        self,
-        name,
-        output=None,
-        input=None,
-        timeout=None,
-        retry=None,
-        pool=None,
-        enable_ulogfs=True,
-        daemon=False,
-        cache=None,
+            self,
+            name,
+            output=None,
+            input=None,
+            timeout=None,
+            retry=None,
+            pool=None,
+            enable_ulogfs=True,
+            daemon=False,
+            cache=None,
+            parallelism=None
     ):
         self.name = name
         self.output = output
@@ -38,6 +39,7 @@ class Template(object):
         self.enable_ulogfs = enable_ulogfs
         self.daemon = daemon
         self.cache = cache
+        self.parallelism: int = parallelism
 
     def to_dict(self):
         template = OrderedDict({"name": self.name})
@@ -49,4 +51,6 @@ class Template(object):
             template["retryStrategy"] = utils.config_retry_strategy(self.retry)
         if self.cache is not None:
             template["memoize"] = self.cache.to_dict()
+        if self.parallelism is not None:
+            template["parallelism"] = self.parallelism
         return template

--- a/couler/tests/__init__.py
+++ b/couler/tests/__init__.py
@@ -10,3 +10,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import couler
+
+couler.config_defaults(name_salter=lambda x: x)

--- a/couler/tests/workflow_basic_test.py
+++ b/couler/tests/workflow_basic_test.py
@@ -357,6 +357,14 @@ class WorkflowBasicTest(ArgoYamlTest):
         ret = couler.workflow_yaml()
         self.assertEqual(code, ret["spec"]["templates"][1]["script"]["source"])
 
+    def test_workflow_name_salt_applies(self):
+        couler.config_defaults(name_salter=lambda name: "%s-salted" % name)
+        couler.config_workflow(name="test_name_salter_applies")
+        ret = couler.workflow_yaml()
+        self.assertEqual(
+            ret["metadata"]["name"], "test_name_salter_applies-salted"
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/examples/default_submitter.py
+++ b/examples/default_submitter.py
@@ -5,7 +5,7 @@ submitter = ArgoSubmitter(namespace="my_namespace")
 
 # Instead of setting up and passing a submitter each time,
 # you can just set it as default!
-ArgoSubmitter.set_default(submitter)
+couler.set_default_submitter(submitter)
 
 couler.run_container(
     image="docker/whalesay",

--- a/examples/default_submitter.py
+++ b/examples/default_submitter.py
@@ -1,0 +1,25 @@
+import couler.argo as couler
+from couler.argo_submitter import ArgoSubmitter
+
+submitter = ArgoSubmitter(namespace="my_namespace")
+
+# Instead of setting up and passing a submitter each time,
+# you can just set it as default!
+ArgoSubmitter.set_default(submitter)
+
+couler.run_container(
+    image="docker/whalesay",
+    command=["cowsay"],
+    args=["hello world with default submitter"],
+)
+# no submitter need be passed now!
+couler.run()
+
+couler.run_container(
+    image="docker/whalesay",
+    command=["cowsay"],
+    args=["yet another hello world with default submitter"],
+)
+# You can still pass a submitter to use,
+# overriding the default submitter if you want to
+couler.run(ArgoSubmitter(namespace="other_namespace"))

--- a/examples/hello_world.py
+++ b/examples/hello_world.py
@@ -7,3 +7,26 @@ couler.run_container(
 
 submitter = ArgoSubmitter()
 result = couler.run(submitter=submitter)
+
+# Instead of passing the submitter each time, you can just set it as default!
+ArgoSubmitter.set_default(submitter)
+
+couler.run_container(
+    image="docker/whalesay",
+    command=["cowsay"],
+    args=["hello world with default submitter"],
+)
+
+result_with_default_submitter = (
+    couler.run()
+)  # no submitter need be passed now!
+
+couler.run_container(
+    image="docker/whalesay",
+    command=["cowsay"],
+    args=["hello world with default submitter 2"],
+)
+
+result_with_default_submitter_2 = (
+    couler.run()
+)  # no submitter need be passed now either!

--- a/examples/hello_world.py
+++ b/examples/hello_world.py
@@ -7,26 +7,3 @@ couler.run_container(
 
 submitter = ArgoSubmitter()
 result = couler.run(submitter=submitter)
-
-# Instead of passing the submitter each time, you can just set it as default!
-ArgoSubmitter.set_default(submitter)
-
-couler.run_container(
-    image="docker/whalesay",
-    command=["cowsay"],
-    args=["hello world with default submitter"],
-)
-
-result_with_default_submitter = (
-    couler.run()
-)  # no submitter need be passed now!
-
-couler.run_container(
-    image="docker/whalesay",
-    command=["cowsay"],
-    args=["hello world with default submitter 2"],
-)
-
-result_with_default_submitter_2 = (
-    couler.run()
-)  # no submitter need be passed now either!

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ pyaml
 kubernetes>=11.0.0
 docker==4.1.0
 Deprecated
+stringcase==1.2.0
 StringGenerator==0.4.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@ pyaml
 kubernetes>=11.0.0
 docker==4.1.0
 Deprecated
-strgen==1.3.1
 StringGenerator==0.4.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ kubernetes>=11.0.0
 docker==4.1.0
 Deprecated
 strgen==1.3.1
+stringcase==1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ kubernetes>=11.0.0
 docker==4.1.0
 Deprecated
 strgen==1.3.1
-stringcase==1.2.0
+StringGenerator==0.4.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pyaml
 kubernetes>=11.0.0
 docker==4.1.0
 Deprecated
+strgen==1.3.1


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fixes/fulfills #214 and #209 
Automatically applies salt to workflow names. The salting function can be changed.

### Why are the changes needed?
Avoids naming clashes between different runs of the same workflow. 

### Does this PR introduce _any_ user-facing change?
Enables `envFrom` fields on containers.

### How was this patch tested?
Tested with live workflows.
