### PR TITLE
docs: Remove link to Slack workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![CI](https://github.com/couler-proj/couler/workflows/CI/badge.svg)](https://github.com/couler-proj/couler/actions?query=event%3Apush+branch%3Amaster)
-[![Slack](https://img.shields.io/badge/Slack-Couler-brightgreen.svg?logo=slack)](https://join.slack.com/t/couler/shared_invite/zt-i0m7ziol-1gz4_p_aXmWM7KVpxJ4k9Q)
 [![Twitter](https://img.shields.io/badge/@CoulerProject--_.svg?style=social&logo=twitter)](https://twitter.com/CoulerProject)
 
 # Couler

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,6 @@
 <img width="300px" src="./assets/logo.svg" alt="Couler Logo">
 
 [![CI](https://github.com/couler-proj/couler/workflows/CI/badge.svg)](https://github.com/couler-proj/couler/actions?query=event%3Apush+branch%3Amaster)
-[![Slack](https://img.shields.io/badge/Slack-Couler-brightgreen.svg?logo=slack)](https://join.slack.com/t/couler/shared_invite/zt-i0m7ziol-1gz4_p_aXmWM7KVpxJ4k9Q)
 [![Twitter](https://img.shields.io/badge/@CoulerProject--_.svg?style=social&logo=twitter)](https://twitter.com/CoulerProject)
 
 ## What is Couler?


### PR DESCRIPTION
This Slack workspace is not active. Argo has also switched to reuse CNCF Slack workspace as well.

I will also post a message on the Slack workspace to let others know.