### PR TITLE
ci: Bump minikube version and fix integration build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
         bash ./scripts/test_go.sh
     - uses: opsgang/ga-setup-minikube@v0.1.1
       with:
-          minikube-version: 1.11.0
+          minikube-version: 1.22.0
           k8s-version: 1.18.3
     - name: Integration tests
       run: |
@@ -69,6 +69,6 @@ jobs:
         kubectl apply -n argo -f manifests/mpi-operator.yaml
 
         go build -buildmode=c-shared -o submit.so go/couler/commands/submit.go
-        # scripts/integration_tests.sh
-        # export E2E_TEST=true
-        # go test -timeout 3m ./go/couler/submitter/... -v
+        scripts/integration_tests.sh
+        export E2E_TEST=true
+        go test -timeout 3m ./go/couler/submitter/... -v


### PR DESCRIPTION
Fixed the following issue:

```
  Warning  FailedScheduling  21s   default-scheduler  0/1 nodes are available: 1 node(s) had taint {node.kubernetes.io/not-ready: }, that the pod didn't tolerate.
  Normal   Scheduled         21s   default-scheduler  Successfully assigned argo/workflow-controller-85f776c7ff-vqfbj to minikube
  Normal   Pulling           20s   kubelet            Pulling image "argoproj/workflow-controller:v2.12.6"
  Warning  FailedScheduling  20s   default-scheduler  AssumePod failed: pod 94efa52a-f88a-4ca2-a2f1-319c2bf4d167 is in the cache, so can't be assumed
```

Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>
