### PR TITLE
fix: Add `--ignore-installed` and `python3 -m pip` when installing Python package

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,10 +117,10 @@ Please see the following sections for installation guide and examples.
 * Couler currently only supports Argo Workflows. Please see instructions [here](https://argoproj.github.io/argo-workflows/quick-start/#install-argo-workflows)
 to install Argo Workflows on your Kubernetes cluster.
 * Install Python 3.6+
-* Install Couler Python SDK via the following `pip` command:
+* Install Couler Python SDK via the following command:
 
 ```bash
-pip install git+https://github.com/couler-proj/couler
+python3 -m pip install git+https://github.com/couler-proj/couler --ignore-installed
 ```
 Alternatively, you can clone this repository and then run the following to install:
 


### PR DESCRIPTION
This fixes the following issue:

```
Collecting git+https://github.com/couler-proj/couler@v0.1.1rc8-stable
  Cloning https://github.com/couler-proj/couler (to revision v0.1.1rc8-stable) to /tmp/pip-req-build-yj7xv69q
Collecting Deprecated
  Downloading Deprecated-1.2.12-py2.py3-none-any.whl (9.5 kB)
...
Successfully built couler wrapt
Installing collected packages: wrapt, Deprecated, websocket-client, docker, pyyaml, oauthlib, requests-oauthlib, pyasn1, rsa, cachetools, pyasn1-modules, google-auth, python-dateutil, urllib3, kubernetes, pyaml, couler
  Attempting uninstall: pyyaml
    Found existing installation: PyYAML 3.12
ERROR: Cannot uninstall 'PyYAML'. It is a distutils installed project and thus we cannot accurately determine which files belong to it which would lead to only a partial uninstall.
WARNING: You are using pip version 20.2.4; however, version 21.2.4 is available.
You should consider upgrading via the '/usr/bin/python3.8 -m pip install --upgrade pip' command.

controlplane $ python3 coin_flip_example.py
Traceback (most recent call last):
  File "coin_flip_example.py", line 1, in <module>
    import couler.argo as couler
ModuleNotFoundError: No module named 'couler'
```