### PR TITLE
feat: Adding toleration support

### DIFF
--- a/couler/core/syntax/__init__.py
+++ b/couler/core/syntax/__init__.py
@@ -22,6 +22,7 @@ from couler.core.syntax.image_pull_secret import (  # noqa: F401
 from couler.core.syntax.loop import map  # noqa: F401
 from couler.core.syntax.predicates import *  # noqa: F401, F403
 from couler.core.syntax.recursion import exec_while  # noqa: F401
+from couler.core.syntax.toleration import add_toleration  # noqa: F401
 from couler.core.syntax.volume import (  # noqa: F401
     add_volume,
     create_workflow_volume,

--- a/couler/core/syntax/toleration.py
+++ b/couler/core/syntax/toleration.py
@@ -1,0 +1,22 @@
+# Copyright 2021 The Couler Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from couler.core import states
+from couler.core.templates.toleration import Toleration
+
+
+def add_toleration(toleration: Toleration):
+    """
+    Add toleration to the workflow.
+    """
+    states.workflow.add_toleration(toleration)

--- a/couler/core/templates/toleration.py
+++ b/couler/core/templates/toleration.py
@@ -15,12 +15,12 @@ from collections import OrderedDict
 
 
 class Toleration(object):
-    def __init__(self, effect, key, operator):
-        self.effect = effect
+    def __init__(self, key, effect, operator):
         self.key = key
+        self.effect = effect
         self.operator = operator
 
     def to_dict(self):
         return OrderedDict(
-            {"effect": self.effect, "key": self.key, "operator": self.operator}
+            {"key": self.key, "effect": self.effect, "operator": self.operator}
         )

--- a/couler/core/templates/toleration.py
+++ b/couler/core/templates/toleration.py
@@ -1,0 +1,26 @@
+# Copyright 2021 The Couler Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections import OrderedDict
+
+
+class Toleration(object):
+    def __init__(self, effect, key, operator):
+        self.effect = effect
+        self.key = key
+        self.operator = operator
+
+    def to_dict(self):
+        return OrderedDict(
+            {"effect": self.effect, "key": self.key, "operator": self.operator}
+        )

--- a/couler/core/templates/workflow.py
+++ b/couler/core/templates/workflow.py
@@ -19,6 +19,7 @@ from couler.core.templates import Container, Job, Script, Step, Template
 from couler.core.templates.image_pull_secret import ImagePullSecret
 from couler.core.templates.volume import Volume
 from couler.core.templates.volume_claim import VolumeClaimTemplate
+from couler.core.templates.toleration import Toleration
 
 
 class Workflow(object):
@@ -76,6 +77,9 @@ class Workflow(object):
 
     def add_image_pull_secret(self, image_pull_secret: ImagePullSecret):
         self.image_pull_secrets.append(image_pull_secret.to_dict())
+
+    def add_toleration(self, toleration: Toleration):
+        self.tolerations.append(toleration.to_dict())
 
     def get_step(self, name):
         return self.steps.get(name, None)
@@ -157,6 +161,8 @@ class Workflow(object):
             workflow_spec.update({"imagePullSecrets": self.image_pull_secrets})
         if self.pvcs:
             workflow_spec.update({"volumeClaimTemplates": self.pvcs})
+        if self.tolerations:
+            workflow_spec.update({"tolerations": self.tolerations})
         if self.dag_mode_enabled():
             dag = {"tasks": list(self.dag_tasks.values())}
             ts = [OrderedDict({"name": entrypoint, "dag": dag})]

--- a/couler/core/templates/workflow.py
+++ b/couler/core/templates/workflow.py
@@ -17,9 +17,9 @@ from inspect import getfullargspec
 from couler.core import utils
 from couler.core.templates import Container, Job, Script, Step, Template
 from couler.core.templates.image_pull_secret import ImagePullSecret
+from couler.core.templates.toleration import Toleration
 from couler.core.templates.volume import Volume
 from couler.core.templates.volume_claim import VolumeClaimTemplate
-from couler.core.templates.toleration import Toleration
 
 
 class Workflow(object):

--- a/couler/core/templates/workflow.py
+++ b/couler/core/templates/workflow.py
@@ -43,6 +43,7 @@ class Workflow(object):
         self.volumes = []
         self.image_pull_secrets = []
         self.pvcs = []
+        self.tolerations = []
         self.service_account = None
         self.security_context = None
 

--- a/couler/core/templates/workflow.py
+++ b/couler/core/templates/workflow.py
@@ -293,6 +293,7 @@ class Workflow(object):
         self.volumes = []
         self.image_pull_secrets = []
         self.pvcs = []
+        self.tolerations = []
         self.service_account = None
         self.security_context = None
         self.dns_config = None

--- a/couler/tests/argo_test.py
+++ b/couler/tests/argo_test.py
@@ -179,6 +179,21 @@ class ArgoTest(ArgoBaseTestCase):
         )
         couler._cleanup()
 
+    def test_run_container_with_toleration(self):
+        toleration = Toleration("example", "Exists", "NoSchedule")
+        # couler.add_toleration(toleration)
+        couler.run_container(
+            image="docker/whalesay:latest",
+            args=["echo -n hello world"],
+            command=["bash", "-c"],
+            step_name="A",
+            tolerations=[toleration],
+        )
+
+        wf = couler.workflow_yaml()
+        self.assertEqual(wf["spec"]["tolerations"][0], toleration.to_dict())
+        couler._cleanup()
+
     def test_run_container_with_image_pull_secret(self):
         secret = ImagePullSecret("test-secret")
         couler.add_image_pull_secret(secret)

--- a/couler/tests/argo_test.py
+++ b/couler/tests/argo_test.py
@@ -180,14 +180,13 @@ class ArgoTest(ArgoBaseTestCase):
         couler._cleanup()
 
     def test_run_container_with_toleration(self):
-        toleration = Toleration("example", "Exists", "NoSchedule")
-        # couler.add_toleration(toleration)
+        toleration = Toleration("example-toleration", "Exists", "NoSchedule")
+        couler.add_toleration(toleration)
         couler.run_container(
             image="docker/whalesay:latest",
             args=["echo -n hello world"],
             command=["bash", "-c"],
             step_name="A",
-            tolerations=[toleration],
         )
 
         wf = couler.workflow_yaml()

--- a/couler/tests/argo_test.py
+++ b/couler/tests/argo_test.py
@@ -20,9 +20,9 @@ import couler.argo as couler
 from couler.core import states
 from couler.core.templates.dns import DnsConfig, DnsConfigOption
 from couler.core.templates.image_pull_secret import ImagePullSecret
+from couler.core.templates.toleration import Toleration
 from couler.core.templates.volume import Volume, VolumeMount
 from couler.core.templates.volume_claim import VolumeClaimTemplate
-from couler.core.templates.toleration import Toleration
 
 
 class ArgoBaseTestCase(unittest.TestCase):

--- a/couler/tests/argo_test.py
+++ b/couler/tests/argo_test.py
@@ -22,6 +22,7 @@ from couler.core.templates.dns import DnsConfig, DnsConfigOption
 from couler.core.templates.image_pull_secret import ImagePullSecret
 from couler.core.templates.volume import Volume, VolumeMount
 from couler.core.templates.volume_claim import VolumeClaimTemplate
+from couler.core.templates.toleration import Toleration
 
 
 class ArgoBaseTestCase(unittest.TestCase):


### PR DESCRIPTION

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. 
-->

This adds `tolerations:` support to couler Workflows.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Tolerations are supported by Argo, but not by Couler.

In our case, we taint our GPU nodes so CPU-only jobs cannot be assigned to them. This PR will allow us to run workflows on these tainted nodes.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->

Yes, it adds an `add_toleration()` method and a `Toleration` class.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Unit tests were added, and this PR was based loosely on a similar PR: https://github.com/couler-proj/couler/pull/238
