### PR TITLE
Enable insecure endpoint for S3Artifacts and S3Artifact usage when workflow is submitted to a namespace other than "default"

### DIFF
--- a/couler/argo.py
+++ b/couler/argo.py
@@ -219,6 +219,7 @@ def create_s3_artifact(
     key=None,
     endpoint=None,
     is_global=False,
+    insecure=False,
 ):
     """
     Configure the object as S3Artifact
@@ -228,6 +229,7 @@ def create_s3_artifact(
     :param accesskey_secret: s3 user key
     :param key: key of s3 object
     :param endpoint: end point of s3
+    :param insecure: use HTTP instead of HTTPS when True
     :return:
     """
     return S3Artifact(
@@ -238,6 +240,7 @@ def create_s3_artifact(
         key=key,
         endpoint=endpoint,
         is_global=is_global,
+        insecure=insecure,
     )
 
 

--- a/couler/core/templates/artifact.py
+++ b/couler/core/templates/artifact.py
@@ -56,6 +56,7 @@ class TypedArtifact(Artifact):
         key=None,
         endpoint="",
         is_global=False,
+        insecure=False,
     ):
         self.type = artifact_type
         self.id = f"output-{self.type}-{utils._get_uuid()}"
@@ -65,6 +66,7 @@ class TypedArtifact(Artifact):
         self.bucket = bucket
         self.key = key
         self.endpoint = endpoint
+        self.insecure = insecure
 
         if accesskey_id and accesskey_secret:
             secret = {"accessKey": accesskey_id, "secretKey": accesskey_secret}
@@ -94,6 +96,8 @@ class TypedArtifact(Artifact):
             config.update({"bucket": self.bucket})
         if self.endpoint:
             config.update({"endpoint": self.endpoint})
+        if self.insecure:
+            config.update({"insecure": self.insecure})
         yaml_output = (
             OrderedDict(
                 {"name": self.id, "path": self.path, self.type: config}
@@ -123,6 +127,7 @@ class S3Artifact(TypedArtifact):
         key=None,
         endpoint="s3.amazonaws.com",
         is_global=False,
+        insecure=False,
     ):
         super().__init__(
             couler.ArtifactType.S3,
@@ -133,6 +138,7 @@ class S3Artifact(TypedArtifact):
             key,
             endpoint,
             is_global,
+            insecure,
         )
 
 

--- a/couler/core/templates/secret.py
+++ b/couler/core/templates/secret.py
@@ -48,7 +48,7 @@ class Secret(object):
             {
                 "apiVersion": "v1",
                 "kind": "Secret",
-                "metadata": {"name": self.name, "namespace": self.namespace},
+                "metadata": {"name": self.name, "namespace": self.namespace} if self.namespace != "default" else {"name": self.name},
                 "type": "Opaque",
                 "data": {},
             }

--- a/couler/tests/artifact_test.py
+++ b/couler/tests/artifact_test.py
@@ -93,6 +93,7 @@ class ArtifactTest(ArgoYamlTest):
         self.assertEqual(s3_config["key"], "s3path/t1")
         self.assertEqual(s3_config["accessKeySecret"]["key"], "accessKey")
         self.assertEqual(s3_config["secretKeySecret"]["key"], "secretKey")
+        self.assertEqual(s3_config["insecure"], True)
 
     def test_output_s3_artifact(self):
         # the content of local file would be uploaded to OSS
@@ -103,6 +104,7 @@ class ArtifactTest(ArgoYamlTest):
             accesskey_secret="abc12345",
             key="s3path/t1",
             endpoint="xyz.com",
+            insecure=True,
         )
         couler.run_container(
             image="docker/whalesay:latest",
@@ -125,6 +127,7 @@ class ArtifactTest(ArgoYamlTest):
             accesskey_secret="abc12345",
             key="s3path/t1",
             endpoint="xyz.com",
+            insecure=True,
         )
 
         # read the content from an S3 bucket

--- a/couler/tests/secret_test.py
+++ b/couler/tests/secret_test.py
@@ -42,7 +42,6 @@ class SecretTest(ArgoYamlTest):
         secret1_yaml = couler.states._secrets[secret1].to_yaml()
         secret2_yaml = couler.states._secrets[secret2].to_yaml()
 
-        self.assertEqual(secret1_yaml["metadata"]["namespace"], "default")
         self.assertEqual(secret1_yaml["metadata"]["name"], "dummy1")
         self.assertEqual(len(secret1_yaml["data"]), 2)
         self.assertEqual(


### PR DESCRIPTION
 S3Artifact endpoint can be set to be insecure (HTTP); Secrets do not have the "namespace: default" entry when no namespace is specified. This enables the use of S3Artifacts when running workflow in a namespace other than "default".

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/couler-proj/couler/blob/master/CODE_OF_CONDUCT.md
  2. Ensure you have added or run the appropriate tests for your PR: https://github.com/couler-proj/couler/blob/master/CONTRIBUTING.md
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
  1. Added a new argument `insecure` to the `create_s3_artifact` function.
  2. Secret yaml file does not put the "namespace: default" entry when no namespace is specified.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. 
-->


### Why are the changes needed?
  1. S3Artifact Endpoint can be HTTP now
  3. Secret yaml file does not put the "namespace: default" entry when no namespace is specified. This enables the use of S3Artifacts to be used when workflow is submitted to a namespace other than "default". Previously it would cause an error where the secret created by the S3Artifact always has the "namespace: default" entry no matter which namespace the workflow is being submitted to.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
This should not break any existing workflow scripts.
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->


### How was this patch tested?
Existing unit tests passed. Couple of changes were made to the test methods to test the new source changes.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
